### PR TITLE
Cgroup2

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+export PATH=$PATH:/usr/local/bin
+use nix

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test/[a-z_]*
 src/lrun
 tools/mirrorfs/mirrorfs
 tools/netns-empty/netns-empty
+tools/netns-empty-lo/netns-empty-lo
 *.so
 
 # include sources
@@ -16,3 +17,6 @@ tools/netns-empty/netns-empty
 !*.h
 !*.rb
 !Makefile
+
+.direnv/
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,3 +6,4 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_subdirectory(src)
+add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(lrun VERSION 0.1 LANGUAGES CXX)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_subdirectory(src)
+
+if($ENV{NOSECCOMP})
+    add_definitions(-DLIBSECCOMP_VERSION_MAJOR=0)
+else()
+    execute_process(COMMAND pkg-config --modversion libseccomp OUTPUT_VARIABLE LIBSECCOMP_VERSION)
+    if(${LIBSECCOMP_VERSION} MATCHES "2.*")
+        add_definitions(-DLIBSECCOMP_VERSION_MAJOR=2)
+    endif()
+endif()
+
+execute_process(COMMAND bash -c "mount -l | grep \"/sys/fs/cgroup type cgroup2\"" RESULT_VARIABLE CGROUP_CHECK)
+if(${CGROUP_CHECK} EQUAL "0")
+    add_definitions(-DCGROUP_VERSION=2)
+else()
+    add_definitions(-DCGROUP_VERSION=1)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(lrun VERSION 0.1 LANGUAGES CXX)
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_subdirectory(src)
-
-if($ENV{NOSECCOMP})
-    add_definitions(-DLIBSECCOMP_VERSION_MAJOR=0)
-else()
-    execute_process(COMMAND pkg-config --modversion libseccomp OUTPUT_VARIABLE LIBSECCOMP_VERSION)
-    if(${LIBSECCOMP_VERSION} MATCHES "2.*")
-        add_definitions(-DLIBSECCOMP_VERSION_MAJOR=2)
-    endif()
-endif()
-
-execute_process(COMMAND bash -c "mount -l | grep \"/sys/fs/cgroup type cgroup2\"" RESULT_VARIABLE CGROUP_CHECK)
-if(${CGROUP_CHECK} EQUAL "0")
-    add_definitions(-DCGROUP_VERSION=2)
-else()
-    add_definitions(-DCGROUP_VERSION=1)
-endif()

--- a/README.textile
+++ b/README.textile
@@ -242,6 +242,14 @@ h3. mirrorfs
 
 A utility helps to set up chroot environments by mirror partial of the current filesystem. The binary is available as lrun-mirrorfs in deb package.
 
+h2. Testing
+
+cgroup v2 support is tested on Ubuntu 22.04. It's a good idea to run the testing in container. You can take test.Dockerfile as a starting point.
+Some useful issues:
+<pre>
+https://github.com/moby/moby/issues/43093
+</pre>
+
 h2. Troubleshooting
 
 *Error: "FATAL: can not mount cgroup memory on '/sys/fs/cgroup/memory' (No such file or directory)"*

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,19 @@
 { pkgs ? import <nixpkgs> { } }:
-
 pkgs.mkShell {
   buildInputs = with pkgs; [
+    mount
+    gnugrep
+
     gcc
     glib
-    # glibc
     rake
     pkg-config
-    libseccomp
+    # libseccomp
+    libseccomp.dev
     cmake
     ninja
   ];
+  shellHook = ''
+    export PATH=$PATH:`pwd`/cmake-build-debug
+  '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    gcc
+    glib
+    # glibc
+    rake
+    pkg-config
+    libseccomp
+    cmake
+    ninja
+  ];
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(PROJECT lrun)
+
+project(${PROJECT} VERSION 0.1 LANGUAGES CXX)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+
+set(CPP_HEADERS
+        cgroup.h
+        config.h
+        fs_tracer.h
+        seccomp.h
+        version.h
+        options/options.h
+        utils/ensure.h
+        utils/for_each.h
+        utils/fs.h
+        utils/linux_only.h
+        utils/log.h
+        utils/now.h
+        utils/re.h
+        utils/strconv.h)
+
+set(CPP_SOURCES
+        cgroup.cc
+        config.cc
+        fs_tracer.cc
+        lrun.cc
+        seccomp.cc
+        options/fopen_filter.cc
+        options/help.cc
+        options/parse.cc
+        utils/fs.cc
+        utils/log.cc
+        utils/now.cc
+        utils/re.cc
+        utils/strconv.cc)
+
+
+add_executable(lrun ${CPP_HEADERS} ${CPP_SOURCES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,11 +3,9 @@ cmake_minimum_required(VERSION 3.12)
 set(PROJECT lrun)
 
 project(${PROJECT} VERSION 0.1 LANGUAGES CXX)
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 
 set(CPP_HEADERS
         cgroup.h
@@ -40,5 +38,28 @@ set(CPP_SOURCES
         utils/re.cc
         utils/strconv.cc)
 
-
 add_executable(lrun ${CPP_HEADERS} ${CPP_SOURCES})
+
+if($ENV{NOSECCOMP})
+    add_definitions(-DLIBSECCOMP_VERSION_MAJOR=0)
+else()
+    execute_process(COMMAND pkg-config --modversion libseccomp OUTPUT_VARIABLE LIBSECCOMP_VERSION)
+    if(${LIBSECCOMP_VERSION} MATCHES "2.*")
+        target_compile_definitions(lrun PUBLIC -DLIBSECCOMP_VERSION_MAJOR=2)
+        find_package(PkgConfig)
+        pkg_search_module(SECCOMP REQUIRED libseccomp)
+        target_include_directories(lrun BEFORE PRIVATE ${SECCOMP_INCLUDE_DIRS})
+        target_link_libraries(lrun PUBLIC ${SECCOMP_LIBRARIES})
+    endif()
+endif()
+
+execute_process(COMMAND bash -c "mount -l | grep \"/sys/fs/cgroup type cgroup2\"" RESULT_VARIABLE CGROUP_CHECK)
+if(${CGROUP_CHECK} EQUAL "0")
+    message("Detected cgroup v2, setting CGROUP_VERSION=2")
+    target_compile_definitions(lrun PUBLIC -DCGROUP_VERSION=2)
+else()
+    message("No cgroup v2, setting CGROUP_VERSION=1")
+    target_compile_definitions(lrun PUBLIC -DCGROUP_VERSION=1)
+endif()
+
+add_custom_command(TARGET lrun POST_BUILD COMMAND sudo install -D -m4550 -oroot -glrun ${CMAKE_CURRENT_BINARY_DIR}/lrun ${CMAKE_BINARY_DIR}/lrun)

--- a/src/Rakefile
+++ b/src/Rakefile
@@ -106,6 +106,21 @@ def get_version
     end
 end
 
+def get_cgroup_version
+  @cgroup_version ||= \
+    begin
+      sh 'mount -l | grep "/sys/fs/cgroup type cgroup2"' do |ok, res|
+        if !ok
+          puts "cgroup v1"
+          1
+        else
+          puts "cgroup v2"
+          2
+        end
+      end
+    end
+end
+
 def get_libseccomp_version
   @libseccomp_version ||=\
     begin
@@ -173,6 +188,7 @@ rule '.o' => '.cc' do |t|
            '-fPIC',
            CXXFLAGS, NODEBUG_FLAG, NOLIBSF_FLAG,
            "-DLIBSECCOMP_VERSION_MAJOR=#{get_libseccomp_version}",
+           "-DCGROUP_VERSION=#{get_cgroup_version}",
            "-DVERSION=\\\"#{get_version}\\\"",
            get_libseccomp_cflags].join(' ')
   require_executable! CXX

--- a/src/cgroup.cc
+++ b/src/cgroup.cc
@@ -43,18 +43,24 @@
 #include "utils/fs.h"
 #include "utils/strconv.h"
 
-#ifdef CGROUP_V1
+
 using namespace lrun;
 
 using std::string;
 using std::list;
 
+#if defined(CGROUP_V1)
 const char Cgroup::subsys_names[4][8] = {
     "cpuacct",
     "memory",
     "devices",
     "freezer",
 };
+#elif defined(CGROUP_V2)
+/**
+ * only cgroup v1 have subsystems.
+ */
+#endif
 
 static struct {
     const char *name;
@@ -68,6 +74,7 @@ static struct {
     {"urandom", 9},
 };
 
+#if defined(CGROUP_V1)
 std::string Cgroup::subsys_base_paths_[sizeof(subsys_names) / sizeof(subsys_names[0])];
 
 int Cgroup::subsys_id_from_name(const char * const name) {
@@ -76,8 +83,15 @@ int Cgroup::subsys_id_from_name(const char * const name) {
     }
     return -1;
 }
+#elif defined(CGROUP_V2)
+#endif
 
+#if defined(CGROUP_V1)
 string Cgroup::base_path(subsys_id_t subsys_id, bool create_on_need) {
+#elif defined(CGROUP_V2)
+string Cgroup::base_path(bool create_on_need) {
+#endif
+#if defined(CGROUP_V1)
     {
         // FIXME cache may not work when user manually umount cgroup
         // check last cached path
@@ -134,21 +148,74 @@ string Cgroup::base_path(subsys_id_t subsys_id, bool create_on_need) {
     }
 
     return (subsys_base_paths_[subsys_id] = dest_path);
+#elif defined(CGROUP_V2)
+    const char * const MNT_SRC_NAME = "cgroup_lrun";
+    const char * MNT_DEST_BASE_PATH = "/sys/fs/cgroup";
+
+    std::map<string, fs::MountEntry> mounts = fs::get_mounts();
+    FOR_EACH_CONST(p, mounts) {
+        const fs::MountEntry& ent = p.second;
+        if (ent.type != string(fs::TYPE_CGROUP2)) continue;
+        return ent.dir;
+    }
+
+    // no cgroups mounted, prepare one
+    if (!create_on_need) return "";
+
+    if (!fs::is_dir(MNT_DEST_BASE_PATH)) {
+        // no /sys/fs/cgroup in system, try conservative location
+        MNT_DEST_BASE_PATH = "/cgroup";
+        mkdir(MNT_DEST_BASE_PATH, 0700);
+    }
+
+    // create and mount cgroup at dest_path
+    string dest_path = string(MNT_DEST_BASE_PATH);
+    INFO("mkdir and mounting '%s'", dest_path.c_str());
+    mkdir(dest_path.c_str(), 0700);
+    /**
+     * TODO: there should be additional flag: nsdelegate,memory_recursiveprot
+     * I don't know whether it is correct putting them in data.
+     */
+    int e = mount(MNT_SRC_NAME, dest_path.c_str(), fs::TYPE_CGROUP2, MS_NOEXEC | MS_NOSUID | MS_RELATIME | MS_NODEV, "nsdelegate,memory_recursiveprot");
+
+    if (e != 0) {
+        int last_err = errno;
+        errno = last_err;
+        FATAL("can not mount cgroup v2 '%s'", dest_path.c_str());
+    }
+    return dest_path;
+#endif
 }
 
+#if defined(CGROUP_V1)
 string Cgroup::path_from_name(subsys_id_t subsys_id, const string& name) {
     return base_path(subsys_id) + "/" + name;
 }
+#elif defined(CGROUP_V2)
+string Cgroup::path_from_name(const string& name) {
+    return base_path() + "/" + name;
+}
+#endif
 
+#if defined(CGROUP_V1)
 string Cgroup::subsys_path(Cgroup::subsys_id_t subsys_id) const {
     return path_from_name(subsys_id, name_);
 }
-
+#elif defined(CGROUP_V2)
+string Cgroup::group_path() const {
+    return path_from_name(name_);
+}
+#endif
 
 int Cgroup::exists(const string& name) {
+#if defined(CGROUP_V1)
     for (int id = 0; id < SUBSYS_COUNT; ++id) {
         if (!fs::is_dir(path_from_name((subsys_id_t)(id), name))) return false;
     }
+#elif defined(CGROUP_V2)
+    if (!fs::is_dir(path_from_name(name))) return false;
+
+#endif
     return true;
 }
 
@@ -160,8 +227,8 @@ Cgroup Cgroup::create(const string& name) {
         cg.name_ = name;
         return cg;
     }
-
     int success = 1;
+#if defined(CGROUP_V1)
     for (int id = 0; id < SUBSYS_COUNT; ++id) {
         string path = path_from_name((subsys_id_t)id, name);
         if (fs::is_dir(path)) continue;
@@ -171,7 +238,13 @@ Cgroup Cgroup::create(const string& name) {
             break;
         }
     }
-
+#elif defined(CGROUP_V2)
+    string path = path_from_name(name);
+    if (mkdir(path.c_str(), 0700)) {
+        ERROR("mkdir '%s': failed", path.c_str());
+        success = 0;
+    }
+#endif
     if (success) cg.name_ = name;
     cg.init_pid_ = 0;
 
@@ -186,8 +259,11 @@ bool Cgroup::valid() const {
 
 void Cgroup::update_output_count() {
     if (!valid()) return;
+#if defined(CGROUP_V1)
     string procs_path = subsys_path(CG_FREEZER) + "/cgroup.procs";
-
+#elif defined(CGROUP_V2)
+    string procs_path = group_path() + "/cgroup.procs";
+#endif
     if (fs::read(procs_path, 4).empty()) return;
 
     FILE * procs = fopen(procs_path.c_str(), "r");
@@ -217,7 +293,11 @@ long long Cgroup::output_usage() const {
 }
 
 list<pid_t> Cgroup::get_pids() {
+#if defined(CGROUP_V1)
     string procs_path = subsys_path(CG_FREEZER) + "/cgroup.procs";
+#elif defined(CGROUP_V2)
+    string procs_path = group_path() + "/cgroup.procs";
+#endif
     FILE * procs = fopen(procs_path.c_str(), "r");
     list<pid_t> pids;
 
@@ -241,9 +321,15 @@ bool Cgroup::has_pid(pid_t pid) {
     char *line = NULL;
     char buf[64];  // FIXME cgroup name is 63 chars long
     while (getline(&line, &len, fp) != -1) {
+#if defined(CGROUP_V1)
         // the line should look like:
         // 4:memory:/cgname
         if (sscanf(line, "%*d:memory:/%63s", buf) != 1)
+#elif defined(CGROUP_V2)
+        // the line should look like:
+        // 0::/cgname
+        if (sscanf(line, "%*d::/%63s", buf) != 1)
+#endif
             continue;
         result = (strncmp(name_.c_str(), buf, sizeof(buf)) == 0);
         break;
@@ -256,6 +342,7 @@ bool Cgroup::has_pid(pid_t pid) {
 static const useconds_t LOOP_ITERATION_INTERVAL = 10000;  // 10 ms
 
 int Cgroup::freeze(bool freeze, int timeout) {
+#if defined(CGROUP_V1)
     if (!valid()) return -1;
     string freeze_state_path = subsys_path(CG_FREEZER) + "/freezer.state";
 
@@ -284,11 +371,42 @@ int Cgroup::freeze(bool freeze, int timeout) {
         INFO("confirmed frozen");
     }
     return 0;
+#elif defined(CGROUP_V2)
+    if (!valid()) return -1;
+    string freeze_state_path = group_path() + "/cgroup.freeze";
+
+    if (!freeze) {
+        INFO("unfreeze");
+        fs::write(freeze_state_path, "0\n");
+    } else {
+        INFO("freezing");
+        fs::write(freeze_state_path, "1\n");
+
+        for (;;) {
+            int frozen = (strncmp(fs::read(freeze_state_path, 4).c_str(), "1", 3) == 0);
+            if (frozen) break;
+
+            timeout--;
+            if (timeout <= 0) {
+                INFO("giving up, not frozen");
+                return -2;
+            }
+
+            usleep(LOOP_ITERATION_INTERVAL);
+        }
+        INFO("confirmed frozen");
+    }
+    return 0;
+#endif
 }
 
 int Cgroup::empty() {
+#if defined(CGROUP_V1)
     string procs_path = subsys_path(CG_FREEZER) + "/cgroup.procs";
+#elif defined(CGROUP_V2)
+    string procs_path = group_path() + "/cgroup.procs";
     return fs::read(procs_path, 4).empty() ? 1 : 0;
+#endif
 }
 
 void Cgroup::killall(bool confirm) {
@@ -338,15 +456,20 @@ int Cgroup::destroy() {
     killall();
 
     int ret = 0;
+#if defined(CGROUP_V1)
     for (int id = 0; id < SUBSYS_COUNT; ++id) {
         string path = subsys_path((subsys_id_t)id);
         if (path.empty()) continue;
         if (fs::is_dir(path)) ret |= rmdir(path.c_str());
     }
+#elif defined(CGROUP_V2)
+    if (fs::is_dir(group_path())) ret |= rmdir(group_path().c_str());
+#endif
 
     return ret;
 }
 
+#if defined(CGROUP_V1)
 int Cgroup::set(subsys_id_t subsys_id, const string& property, const string& value) {
     INFO("set cgroup %s/%s to %s", subsys_path(subsys_id).c_str(), property.c_str(), value.c_str());
     return fs::write(subsys_path(subsys_id) + "/" + property, value);
@@ -360,74 +483,156 @@ int Cgroup::inherit(subsys_id_t subsys_id, const string& property) {
     string value = fs::read(base_path(subsys_id, false) + "/" + property);
     return fs::write(subsys_path(subsys_id) + "/" + property, value);
 }
+#elif defined(CGROUP_V2)
+int Cgroup::set(const string& property, const string& value) {
+    INFO("set cgroup %s to %s", property.c_str(), value.c_str());
+    return fs::write(group_path() + "/" + property, value);
+}
+
+string Cgroup::get(const string& property, size_t max_length) const {
+    return fs::read(group_path() + "/" + property, max_length);
+}
+
+int Cgroup::inherit(const string& property) {
+    string value = fs::read(base_path(false) + "/" + property);
+    return fs::write(group_path() + "/" + property, value);
+}
+#endif
 
 int Cgroup::attach(pid_t pid) {
     char pidbuf[32];
     snprintf(pidbuf, sizeof(pidbuf), "%lu\n", (unsigned long)pid);
 
     int ret = 0;
+#if defined(CGROUP_V1)
     for (int id = 0; id < SUBSYS_COUNT; ++id) {
         string path = subsys_path((subsys_id_t)id);
         // FIXME: It seems pid should be write into /cgroup.procs and tid should be write into /tasks
         ret |= fs::write(path + "/tasks", pidbuf);
     }
+#elif defined(CGROUP_V2)
+    ret |= fs::write(group_path() + "/cgroup.procs", pidbuf);
+#endif
 
     return ret;
 }
 
 int Cgroup::limit_devices() {
     int e = 0;
+#if defined(CGROUP_V1)
     e += set(CG_DEVICES, "devices.deny", "a");
     for (size_t i = 0; i < sizeof(basic_devices) / sizeof(basic_devices[0]); ++i) {
         long minor = basic_devices[i].minor;
         string v = string("c 1:" + strconv::from_long(minor) + " rwm");
         e += set(CG_DEVICES, "devices.allow", v);
     }
+#elif defined(CGROUP_V2)
+    /**
+     * cgroup v2 not support limit devices by default:
+     *      Cgroup v2 device controller has no interface files and is implemented
+     *      on top of cgroup BPF. To control access to device files, a user may
+     *      create bpf programs of the BPF_CGROUP_DEVICE type and attach them
+     */
+#endif
     return e ? -1 : 0;
 }
 
 int Cgroup::reset_usages() {
     int e = 0;
+#if defined(CGROUP_V1)
     e += set(CG_CPUACCT, "cpuacct.usage", "0");
     e += set(CG_MEMORY, "memory.max_usage_in_bytes", "0") * set(CG_MEMORY, "memory.memsw.max_usage_in_bytes", "0");
     output_counter_.clear();
+#elif defined(CGROUP_V2)
+    /**
+     * cgroup v2 seems not support reset status
+     */
+#endif
     return e ? -1 : 0;
 }
 
 int Cgroup::reset_cpu_usage() {
     int e = 0;
+#if defined(CGROUP_V1)
     e = set(CG_CPUACCT, "cpuacct.usage", "0");
+#elif defined(CGROUP_V2)
+    /**
+     * cgroup v2 seems not support reset status
+     */
+#endif
     return e ? -1 : 0;
 }
 
 double Cgroup::cpu_usage() const {
+#if defined(CGROUP_V1)
     string cpu_usage = get(CG_CPUACCT, "cpuacct.usage", 31);
     // convert from nanoseconds to seconds
     return strconv::to_double(cpu_usage) / 1e9;
+#elif defined(CGROUP_V2)
+    char cpu_usage[32];
+    string content = get("cpu.stat", 32);
+    if (sscanf(content.c_str(), "usage_usec %31s", cpu_usage) == 0) {
+        return 0.0;
+    }
+    // convert from useconds(microseconds) to seconds
+    return strconv::to_double(cpu_usage) / 1e6;
+#endif
 }
 
 long long Cgroup::memory_current() const {
+#if defined(CGROUP_V1)
     string usage = get(CG_MEMORY, "memory.memsw.usage_in_bytes");
     if (usage.empty()) usage = get(CG_MEMORY, "memory.usage_in_bytes");
     return strconv::to_longlong(usage);
+#elif defined(CGROUP_V2)
+    string usage = get("memory.current");
+    /**
+     * in cgroup v2, there is no memory.swap.peak.
+     * so we do not count swap usage currently.
+     */
+    // string swap_usage = get("memory.swap.current");
+    // return strconv::to_longlong(usage) + strconv::to_longlong(swap_usage);
+    return strconv::to_longlong(usage);
+#endif
 }
 
 long long Cgroup::memory_peak() const {
+#if defined(CGROUP_V1)
     string usage = get(CG_MEMORY, "memory.memsw.max_usage_in_bytes");
     if (usage.empty()) usage = get(CG_MEMORY, "memory.max_usage_in_bytes");
+#elif defined(CGROUP_V2)
+    /**
+     * in cgroup v2, there is no memory.swap.peak.
+     * so we do not count swap usage currently.
+     */
+    string usage = get("memory.peak");
+    return strconv::to_longlong(usage);
+#endif
     return strconv::to_longlong(usage);
 }
 
 long long Cgroup::memory_limit() const {
+#if defined(CGROUP_V1)
     string limit = get(CG_MEMORY, "memory.memsw.limit_in_bytes");
     if (limit.empty()) limit = get(CG_MEMORY, "memory.limit_in_bytes");
+#elif defined(CGROUP_V2)
+    string limit = get("memory.max");
+    if (strcmp(limit.c_str(), "max") == 0) return LLONG_MAX;
+#endif
     return strconv::to_longlong(limit);
 }
 
 bool Cgroup::is_under_oom() const {
+#if defined(CGROUP_V1)
     string content = get(CG_MEMORY, "memory.oom_control");
     return content.find("under_oom 1") != string::npos;
-
+#elif defined(CGROUP_V2)
+    string content = get( "memory.events");
+    string sub_content = content.substr(content.find("oom "));
+    int count;
+    if (sscanf(sub_content.c_str(), "oom %d", &count) == 0) return false;
+    return count > 0;
+#endif
 }
 
 long long Cgroup::set_memory_limit(long long bytes) {
@@ -435,18 +640,30 @@ long long Cgroup::set_memory_limit(long long bytes) {
 
     if (bytes <= 0) {
         // read base (parent) cgroup properties
+#if defined(CGROUP_V1)
         e *= inherit(CG_MEMORY, "memory.limit_in_bytes");
         e *= inherit(CG_MEMORY, "memory.memsw.limit_in_bytes");
+#elif defined(CGROUP_V2)
+        e *= inherit("memory.max");
+#endif
     } else {
+#if defined(CGROUP_V1)
         e *= set(CG_MEMORY, "memory.limit_in_bytes", strconv::from_longlong(bytes));
         e *= set(CG_MEMORY, "memory.memsw.limit_in_bytes", strconv::from_longlong(bytes));
+#elif defined(CGROUP_V2)
+        e *= set("memory.max", strconv::from_longlong(bytes));
+#endif
     }
 
     if (e) {
         return -1;
     } else {
         // The kernel might "adjust" the memory limit. Read it back.
+#if defined(CGROUP_V1)
         string limit = get(CG_MEMORY, "memory.memsw.limit_in_bytes");
+#elif defined(CGROUP_V2)
+        string limit = get("memory.max");
+#endif
         return strconv::to_longlong(limit);
     }
 }
@@ -1221,6 +1438,7 @@ pid_t Cgroup::spawn(spawn_arg& arg) {
         goto cleanup;
     }
 
+#if defined(CGROUP_V1)
     // the child has exec successfully
     // disable oom killer because it will make dmesg noisy.
     // Note: a process can enter D (uninterruptable sleep) status
@@ -1228,1169 +1446,13 @@ pid_t Cgroup::spawn(spawn_arg& arg) {
     // or enlarge memory limit
     INFO("disabling oom killer");
     if (set(CG_MEMORY, "memory.oom_control", "1\n")) INFO("can not set memory.oom_control");
+#elif defined(CGROUP_V2)
+    /**
+     * oom kill disable is not available for cgroup v2.
+     */
+#endif
 
 cleanup:
     close(arg.sockets[1]);
     return child_pid;
 }
-#endif
-
-#ifdef CGROUP_V2
-using namespace lrun;
-
-using std::string;
-using std::list;
-
-//const char Cgroup::subsys_names[4][8] = {
-//        "cgroup",
-//        "cpu",
-//        "memory",
-//        "devices",
-//};
-
-static struct {
-    const char *name;
-    unsigned int minor;
-    // major is missing because all basic_devices have major = 1
-} basic_devices[] = {
-        {"null", 3},
-        {"zero", 5},
-        {"full", 7},
-        {"random", 8},
-        {"urandom", 9},
-};
-
-//std::string Cgroup::subsys_base_paths_[sizeof(subsys_names) / sizeof(subsys_names[0])];
-//
-//int Cgroup::subsys_id_from_name(const char * const name) {
-//    for (size_t i = 0; i < sizeof(Cgroup::subsys_names) / sizeof(Cgroup::subsys_names[0]); ++i) {
-//        if (strcmp(name, subsys_names[i]) == 0) return i;
-//    }
-//    return -1;
-//}
-
-string Cgroup::base_path(bool create_on_need) {
-
-    const char * const MNT_SRC_NAME = "cgroup_lrun";
-    const char * MNT_DEST_BASE_PATH = "/sys/fs/cgroup";
-
-    std::map<string, fs::MountEntry> mounts = fs::get_mounts();
-    FOR_EACH_CONST(p, mounts) {
-        const fs::MountEntry& ent = p.second;
-        if (ent.type != string(fs::TYPE_CGROUP2)) continue;
-        return ent.dir;
-    }
-
-    // no cgroups mounted, prepare one
-    if (!create_on_need) return "";
-
-    if (!fs::is_dir(MNT_DEST_BASE_PATH)) {
-        // no /sys/fs/cgroup in system, try conservative location
-        MNT_DEST_BASE_PATH = "/cgroup";
-        mkdir(MNT_DEST_BASE_PATH, 0700);
-    }
-
-    // create and mount cgroup at dest_path
-    string dest_path = string(MNT_DEST_BASE_PATH);
-    INFO("mkdir and mounting '%s'", dest_path.c_str());
-    mkdir(dest_path.c_str(), 0700);
-    // TODO: there should be additional flag: nsdelegate,memory_recursiveprot
-    // I don't know whether it is correct putting them in data.
-    int e = mount(MNT_SRC_NAME, dest_path.c_str(), fs::TYPE_CGROUP2, MS_NOEXEC | MS_NOSUID | MS_RELATIME | MS_NODEV, "nsdelegate,memory_recursiveprot");
-
-    if (e != 0) {
-        int last_err = errno;
-        errno = last_err;
-        FATAL("can not mount cgroup v2 '%s'", dest_path.c_str());
-    }
-    return dest_path;
-}
-
-string Cgroup::path_from_name(const string& name) {
-    return base_path() + "/" + name;
-}
-
-string Cgroup::group_path() const {
-    return path_from_name(name_);
-}
-
-int Cgroup::exists(const string& name) {
-    if (!fs::is_dir(path_from_name(name))) return false;
-    return true;
-}
-
-Cgroup Cgroup::create(const string& name) {
-    Cgroup cg;
-
-    if (exists(name)) {
-        INFO("create cgroup '%s': already exists", name.c_str());
-        cg.name_ = name;
-        return cg;
-    }
-
-    int success = 1;
-
-    string path = path_from_name(name);
-    if (mkdir(path.c_str(), 0700)) {
-        ERROR("mkdir '%s': failed", path.c_str());
-        success = 0;
-    }
-
-    if (success) cg.name_ = name;
-    cg.init_pid_ = 0;
-
-    return cg;
-}
-
-Cgroup::Cgroup() { }
-
-bool Cgroup::valid() const {
-    return !name_.empty() && exists(name_);
-}
-
-void Cgroup::update_output_count() {
-    if (!valid()) return;
-    string procs_path = group_path() + "/cgroup.procs";
-
-    if (fs::read(procs_path, 4).empty()) return;
-
-    FILE * procs = fopen(procs_path.c_str(), "r");
-    char spid[26]; // sizeof(pid_t) * 3 + 2, assuming sizeof(pid_t) is 8
-    while (fscanf(procs, "%25s", spid) == 1) {
-        unsigned long pid;
-        unsigned long long bytes = 0;
-        if (sscanf(spid, "%lu", &pid) == 0) continue;
-        FILE * io = fopen((string(fs::PROC_PATH) + "/" + spid + "/io").c_str(), "r");
-        if (!io) continue;
-        int res = 0;
-        res = fscanf(io, "rchar: %*s\nwchar: %Lu", &bytes);
-        if (res == 1) {
-            if (output_counter_[pid] < bytes) output_counter_[pid] = bytes;
-        }
-        fclose(io);
-    }
-    fclose(procs);
-}
-
-long long Cgroup::output_usage() const {
-    long long bytes = 0;
-    FOR_EACH_CONST(p, output_counter_) {
-        bytes += p.second;
-    }
-    return bytes;
-}
-
-list<pid_t> Cgroup::get_pids() {
-    string procs_path = group_path() + "/cgroup.procs";
-    FILE * procs = fopen(procs_path.c_str(), "r");
-    list<pid_t> pids;
-    if (procs) {
-        unsigned long pid;
-        while (fscanf(procs, "%lu", &pid) == 1) pids.push_back((pid_t)pid);
-        fclose(procs);
-    }
-    return pids;
-}
-
-bool Cgroup::has_pid(pid_t pid) {
-    bool result = false;
-
-    char path[sizeof(long) * 3 + sizeof("/proc//cgroup")];
-    snprintf(path, sizeof(path), "/proc/%ld/cgroup", (long)pid);
-    FILE *fp = fopen(path, "r");
-    if (!fp) return false;
-
-    size_t len = 0;
-    char *line = NULL;
-    char buf[64];  // FIXME cgroup name is 63 chars long
-    while (getline(&line, &len, fp) != -1) {
-        // the line should look like:
-        // 0::/cgname
-        if (sscanf(line, "%*d::/%63s", buf) != 1)
-            continue;
-        result = (strncmp(name_.c_str(), buf, sizeof(buf)) == 0);
-        break;
-    }
-    if (line) free(line);
-    fclose(fp);
-    return result;
-}
-
-static const useconds_t LOOP_ITERATION_INTERVAL = 10000;  // 10 ms
-
-int Cgroup::freeze(bool freeze, int timeout) {
-    if (!valid()) return -1;
-    string freeze_state_path = group_path() + "/cgroup.freeze";
-
-    if (!freeze) {
-        INFO("unfreeze");
-        fs::write(freeze_state_path, "0\n");
-    } else {
-        INFO("freezing");
-        fs::write(freeze_state_path, "1\n");
-
-        for (;;) {
-            int frozen = (strncmp(fs::read(freeze_state_path, 4).c_str(), "1", 3) == 0);
-            if (frozen) break;
-
-            timeout--;
-            if (timeout <= 0) {
-                INFO("giving up, not frozen");
-                return -2;
-            }
-
-            usleep(LOOP_ITERATION_INTERVAL);
-        }
-        INFO("confirmed frozen");
-    }
-    return 0;
-}
-
-int Cgroup::empty() {
-    string procs_path = group_path() + "/cgroup.procs";
-    return fs::read(procs_path, 4).empty() ? 1 : 0;
-}
-
-void Cgroup::killall(bool confirm) {
-    // The init pid can be outside the cgroup task list. Therefore do not
-    // test "empty()" here.
-    if (!valid()) return;
-
-    if (init_pid_) {
-        if (init_pid_ > 0) {
-            // if init pid exists, just kill it and the kernel will kill all
-            // remaining processes in the same pid ns.
-            // because our init process (clone_init_fn) won't allocate memory,
-            // it will not enter D state and is safe to kill.
-            kill(init_pid_, SIGKILL);
-            // cancel memory limit. this will wake up some D state processes,
-            // which are allocating memory and reached memory limit.
-            set_memory_limit(-1);
-            INFO("sent SIGKILL to init process %lu", (unsigned long)init_pid_);
-            init_pid_ = -1;
-        }
-
-        if (confirm) {
-            // wait and confirm that processes are gone
-            for (int clear = 0; clear == 0;) {
-                if (!valid() || empty()) break;
-                usleep(LOOP_ITERATION_INTERVAL);
-            }
-        }
-    } else {
-        // legacy (unreliable) way to kill processes, or not using a pid
-        // namespace
-        while (valid() && !empty()) {
-            freeze(true, 2);
-            list<pid_t> pids = get_pids();
-            FOR_EACH(p, pids) kill(p, SIGKILL);
-            INFO("sent SIGKILLs to %lu processes", (unsigned long)pids.size());
-            if (!confirm) break;
-            freeze(false, 1);
-            if (!empty()) usleep(LOOP_ITERATION_INTERVAL);
-        }
-    }
-
-    return;
-}
-
-int Cgroup::destroy() {
-    killall();
-
-    int ret = 0;
-    if (fs::is_dir(group_path())) ret |= rmdir(group_path().c_str());
-
-    return ret;
-}
-
-int Cgroup::set(const string& property, const string& value) {
-    INFO("set cgroup %s to %s", property.c_str(), value.c_str());
-    return fs::write(group_path() + "/" + property, value);
-}
-
-string Cgroup::get(const string& property, size_t max_length) const {
-    return fs::read(group_path() + "/" + property, max_length);
-}
-
-int Cgroup::inherit(const string& property) {
-    string value = fs::read(base_path(false) + "/" + property);
-    return fs::write(group_path() + "/" + property, value);
-}
-
-int Cgroup::attach(pid_t pid) {
-    char pidbuf[32];
-    snprintf(pidbuf, sizeof(pidbuf), "%lu\n", (unsigned long)pid);
-
-    int ret = 0;
-    ret |= fs::write(group_path() + "/cgroup.procs", pidbuf);
-
-    return ret;
-}
-
-int Cgroup::limit_devices() {
-    int e = 0;
-    // TODO: implement
-//    e += set(CG_DEVICES, "devices.deny", "a");
-//    for (size_t i = 0; i < sizeof(basic_devices) / sizeof(basic_devices[0]); ++i) {
-//        long minor = basic_devices[i].minor;
-//        string v = string("c 1:" + strconv::from_long(minor) + " rwm");
-//        e += set(CG_DEVICES, "devices.allow", v);
-//    }
-    return e ? -1 : 0;
-}
-
-int Cgroup::reset_usages() {
-    int e = 0;
-    // FIXME: maybe not available in v2
-//    e += set(CG_CPUACCT, "cpuacct.usage", "0");
-//    e += set(CG_MEMORY, "memory.max_usage_in_bytes", "0") * set(CG_MEMORY, "memory.memsw.max_usage_in_bytes", "0");
-//    output_counter_.clear();
-    return e ? -1 : 0;
-}
-
-int Cgroup::reset_cpu_usage() {
-    int e = 0;
-    // FIXME: maybe not available in v2
-//    e = set(CG_CPUACCT, "cpuacct.usage", "0");
-    return e ? -1 : 0;
-}
-
-double Cgroup::cpu_usage() const {
-    char cpu_usage[32];
-    string content = get("cpu.stat", 32);
-    if (sscanf(content.c_str(), "usage_usec %31s", cpu_usage) == 0) {
-        return 0.0;
-    }
-    // convert from useconds(microseconds) to seconds
-    return strconv::to_double(cpu_usage) / 1e6;
-}
-
-long long Cgroup::memory_current() const {
-    string usage = get("memory.current");
-//    string swap_usage = get("memory.swap.current");
-    return strconv::to_longlong(usage);
-//    return strconv::to_longlong(memory_usage) + strconv::to_longlong(swap_usage)
-}
-
-long long Cgroup::memory_peak() const {
-    string usage = get("memory.peak");
-    return strconv::to_longlong(usage);
-}
-
-long long Cgroup::memory_limit() const {
-    string limit = get("memory.max");
-    if (strcmp(limit.c_str(), "max") == 0) return LLONG_MAX;
-//    if (limit.empty()) limit = get(CG_MEMORY, "memory.limit_in_bytes");
-    return strconv::to_longlong(limit);
-}
-
-bool Cgroup::is_under_oom() const {
-    string content = get( "memory.events");
-    string sub_content = content.substr(content.find("oom "));
-    int count;
-    if (sscanf(sub_content.c_str(), "oom %d", &count) == 0) return false;
-    return count > 0;
-}
-
-long long Cgroup::set_memory_limit(long long bytes) {
-    int e = 1;
-
-    if (bytes <= 0) {
-        // read base (parent) cgroup properties
-        e *= inherit("memory.max");
-    } else {
-        e *= set("memory.max", strconv::from_longlong(bytes));
-    }
-
-    if (e) {
-        return -1;
-    } else {
-        // The kernel might "adjust" the memory limit. Read it back.
-        string limit = get("memory.max");
-        return strconv::to_longlong(limit);
-    }
-}
-
-// following functions are called by clone_main_fn
-
-__attribute__((unused)) static void do_set_sysctl() {
-    INFO("set sysctl settings");
-    // skip slow oom scaning and do not write syslog
-    fs::write("/proc/sys/vm/oom_kill_allocating_task", "1\n");
-    fs::write("/proc/sys/vm/oom_dump_tasks", "0\n");
-    // block dmesg access
-    fs::write("/proc/sys/kernel/dmesg_restrict", "1\n");
-}
-
-static void do_privatize_filesystem(__attribute__((unused)) const Cgroup::spawn_arg& arg) {
-    // make sure filesystem not be shared
-    // ignore this step for old systems without these features
-    int type = MS_PRIVATE | MS_REC;
-    if (type && fs::mount_set_shared("/", MS_PRIVATE | MS_REC)) {
-        FATAL("can not mount --make-rprivate /");
-    }
-}
-
-static void do_remounts(const Cgroup::spawn_arg& arg) {
-    FOR_EACH(p, arg.remount_list) {
-        const string& dest = p.first;
-        unsigned long flags = p.second;
-        // tricky point: if the original mount point has --bind, remount with --bind
-        // can make it less likely to get "device busy" message
-        if (arg.bindfs_dest_set.count(dest)) flags |= MS_BIND;
-
-        INFO("remount %s", dest.c_str());
-        for (;;) {
-            if (fs::remount(dest, flags) == 0) break;
-            if (flags & MS_BIND) FATAL("remount '%s' failed", dest.c_str());
-            flags |= MS_BIND;
-        }
-    }
-}
-
-static void do_mount_bindfs(const Cgroup::spawn_arg& arg) {
-    // bind fs mounts
-    FOR_EACH(p, arg.bindfs_list) {
-        const string& dest = p.first;
-        const string& src = p.second;
-
-        INFO("mount bind %s -> %s", src.c_str(), dest.c_str());
-        if (fs::mount_bind(src, dest)) {
-            FATAL("mount bind '%s' -> '%s' failed", src.c_str(), dest.c_str());
-        }
-    }
-}
-
-static void do_chroot(const Cgroup::spawn_arg& arg) {
-    // chroot to a prepared place
-    if (!arg.chroot_path.empty()) {
-        const string& path = arg.chroot_path;
-
-        INFO("chroot %s", path.c_str());
-        if (chroot(path.c_str())) {
-            FATAL("chroot '%s' failed", path.c_str());
-        }
-    }
-}
-
-static void do_umount_outside_chroot(const Cgroup::spawn_arg& arg) {
-    if (!arg.umount_outside) return;
-    if (arg.chroot_path.empty()) return;
-
-    std::map<string, fs::MountEntry> mounts = fs::get_mounts();
-    list<string> umount_list;
-    FOR_EACH(p, mounts) {
-        const string& dest = p.second.dir;
-        if (arg.chroot_path.substr(0, dest.length()) == dest) continue;
-        if (dest.substr(0, arg.chroot_path.length()) == arg.chroot_path) continue;
-        umount_list.push_front(dest);
-    }
-
-    // umount in reversed order
-    FOR_EACH(dest, umount_list) {
-        INFO("umount %s", dest.c_str());
-        if (umount2(dest.c_str(), MNT_DETACH) == -1) {
-            WARNING("cannot umount %s", dest.c_str());
-        }
-    }
-}
-
-static bool should_mount_proc(const Cgroup::spawn_arg& arg) {
-    if (!fs::is_accessible(fs::join(arg.chroot_path, fs::PROC_PATH), X_OK)) return false;
-    return (arg.clone_flags & CLONE_NEWPID) != 0 || !arg.chroot_path.empty();
-}
-
-static bool should_hide_sensitive(const Cgroup::spawn_arg& arg) {
-    if (!should_mount_proc(arg)) return false;
-
-    // currently there is no option about this behavior
-    // when `--no-new-privs false`, the user does not want to hide anything
-    if (!arg.no_new_privs) return false;
-    if (getenv("LRUN_DO_NOT_HIDE_SENSITIVE")) return false;
-    return true;
-}
-
-static const char * get_proc_fs_type(const Cgroup::spawn_arg& arg) {
-    // use "liteproc" when possible
-    static const char proc_fs[] = "proc";
-    static const char liteproc_fs[] = "liteproc";
-    // when `--no-new-privs false`, the user does not want to hide anything
-    if (!arg.no_new_privs) return proc_fs;
-    // 4KB is probably enough for /proc/filesystems.
-    // on my system, it is 398 bytes now.
-    if (fs::read("/proc/filesystems", 4095).find("liteproc") == string::npos) {
-        return proc_fs;
-    } else {
-        return liteproc_fs;
-    }
-}
-
-static void do_mount_proc(const Cgroup::spawn_arg& arg) {
-    // mount /proc if pid namespace is enabled and the directory exists
-    if (!should_mount_proc(arg)) return;
-    string dest = fs::join(arg.chroot_path, fs::PROC_PATH);
-    INFO("mount procfs at %s", dest.c_str());
-    const char * mount_opts = should_hide_sensitive(arg) ? "hidepid=2" : NULL;
-    if (mount(NULL, dest.c_str(), get_proc_fs_type(arg), MS_NOEXEC | MS_NOSUID, mount_opts)) {
-        FATAL("mount procfs failed");
-    }
-}
-
-static void do_hide_sensitive(const Cgroup::spawn_arg& arg) {
-    if (!should_hide_sensitive(arg)) return;
-    string proc_sys_path = fs::join(arg.chroot_path, "/proc/sys");
-    if (fs::is_accessible(proc_sys_path, X_OK)) {
-        mount(NULL, proc_sys_path.c_str(), "tmpfs", MS_NOSUID | MS_RDONLY, "size=0");
-    }
-}
-
-static list<int> get_fds() {
-    list<int> fds;
-
-    struct dirent **namelist = 0;
-    int nlist = scandir("/proc/self/fd", &namelist, 0, alphasort);
-    for (int i = 0; i < nlist; ++i) {
-        const char * name = namelist[i]->d_name;
-        // skip . and ..
-        if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0) {
-            int fd = -1;
-            if (sscanf(name, "%d", &fd) != 1) continue;
-            // scandir will use a dirfd. verify existance of fds
-            if (fs::is_fd_valid(fd))
-                fds.push_back(fd);
-        }
-        free(namelist[i]);
-    }
-    if (namelist) free(namelist);
-
-    return fds;
-}
-
-static void do_set_uts(const Cgroup::spawn_arg& arg) {
-    int e;
-    if (!arg.uts.domainname.empty()) {
-        INFO("setdomainname: %s", arg.uts.domainname.c_str());
-        e = setdomainname(arg.uts.domainname.c_str(), arg.uts.domainname.length());
-        if (e == -1) {
-            FATAL("setdomainname '%s' failed", arg.uts.domainname.c_str());
-            exit(-1);
-        }
-    }
-    if (!arg.uts.nodename.empty()) {
-        INFO("sethostname: %s", arg.uts.nodename.c_str());
-        e = sethostname(arg.uts.nodename.c_str(), arg.uts.nodename.length());
-        if (e == -1) {
-            FATAL("sethostname '%s' failed", arg.uts.nodename.c_str());
-            exit(-1);
-        }
-    }
-
-    // [[[cog
-    //  import cog
-    //  opts = {'release': 'osrelease', 'sysname': 'ostype', 'version': 'version'}
-    //  for opt, name in opts.items():
-    //    cog.out('''
-    //      if (!arg.uts.%(opt)s.empty() && fs::is_accessible("/proc/sys/utsmod/%(name)s"), W_OK) {
-    //          fs::write("/proc/sys/utsmod/%(name)s", arg.uts.%(opt)s);
-    //      }''' % {'name': name, 'opt': opt}, trimblanklines=True)
-    // ]]]
-    if (!arg.uts.release.empty() && fs::is_accessible("/proc/sys/utsmod/osrelease"), W_OK) {
-        fs::write("/proc/sys/utsmod/osrelease", arg.uts.release);
-    }
-    if (!arg.uts.sysname.empty() && fs::is_accessible("/proc/sys/utsmod/ostype"), W_OK) {
-        fs::write("/proc/sys/utsmod/ostype", arg.uts.sysname);
-    }
-    if (!arg.uts.version.empty() && fs::is_accessible("/proc/sys/utsmod/version"), W_OK) {
-        fs::write("/proc/sys/utsmod/version", arg.uts.version);
-    }
-    // [[[end]]]
-}
-
-static void do_set_netns(const Cgroup::spawn_arg& arg) {
-    if (arg.netns_fd == -1) return;
-
-    INFO("set netns")
-
-    // older glibc does not have setns
-    if (syscall(SYS_setns, arg.netns_fd, CLONE_NEWNET)) {
-        FATAL("can not set netns");
-    };
-}
-
-static void do_fd_redirect(int fd_dst, int fd_src) {
-    if (fd_src >= 0 && fd_src != fd_dst) {
-        INFO("dup2 %d %d", fd_src, fd_dst);
-        int ret = dup2(fd_src, fd_dst);
-        if (ret == -1) {
-            FATAL("cannot dup %d", fd_src);
-        }
-    }
-}
-
-static void fd_set_cloexec(int fd, int enforce = 1) {
-    if (fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) | FD_CLOEXEC)) {
-        if (enforce) {
-            FATAL("fcntl %d failed", fd);
-        } else {
-            // fd can become invalid across namespaces
-            close(fd);
-        }
-    }
-}
-
-static void do_process_fds(const Cgroup::spawn_arg& arg) {
-    // this is for parent process
-    close(arg.sockets[1]);
-
-#ifndef NDEBUG
-    // make a copy of log fd because we may soon lose stderr
-    // this affects INFO, WARN, ERROR, FATAL
-    int flog_fd = dup(STDERR_FILENO);
-    flog = fdopen(flog_fd, "a");
-#endif
-
-    do_fd_redirect(STDOUT_FILENO, arg.stdout_fd);
-    do_fd_redirect(STDERR_FILENO, arg.stderr_fd);
-
-    INFO("applying FD_CLOEXEC");
-    list<int> fds = get_fds();
-    FOR_EACH(fd, fds) {
-        if (fd != STDERR_FILENO && fd != STDIN_FILENO && fd != STDOUT_FILENO
-            && arg.keep_fds.count(fd) == 0) {
-            fd_set_cloexec(fd, 0 /* close that fd on error */);
-        }
-    }
-}
-
-static void do_mount_tmpfs(const Cgroup::spawn_arg& arg) {
-    // setup other tmpfs mounts
-    FOR_EACH(p, arg.tmpfs_list) {
-        const char * dest = p.first.c_str();
-        const long long& size = p.second;
-
-        INFO("mount tmpfs %s (size = %lld kB)", dest, size);
-
-        int e = 0;
-        if (size <= 0) {
-            // treat as read-only
-            e = mount(NULL, dest, "tmpfs", MS_NOSUID | MS_RDONLY, "size=0");
-        } else {
-            e = mount(NULL, dest, "tmpfs", MS_NOSUID, ((string)("mode=0777,size=" + strconv::from_longlong(size))).c_str());
-        }
-        if (e) {
-            FATAL("mount tmpfs '%s' failed", dest);
-        }
-    }
-}
-
-static void do_remount_dev(const Cgroup::spawn_arg& arg) {
-    if (!arg.remount_dev) return;
-
-    INFO("remount /dev");
-
-    int e;
-    // mount a minimal tmpfs to /dev
-    e = mount(NULL, "/dev", "tmpfs", MS_NOSUID, "size=64,mode=0755,uid=0,gid=0");
-    if (e) FATAL("remount /dev failed");
-
-    // create basic devices
-    for (size_t i = 0; i < sizeof(basic_devices) / sizeof(basic_devices[0]); ++i) {
-        string path = string("/dev/") + basic_devices[i].name;
-        unsigned int minor = basic_devices[i].minor;
-        e = mknod(path.c_str(), S_IFCHR | 0666 /* mode */, makedev(1 /* major */, minor));
-        if (!e) e = chmod(path.c_str(), 0666);
-        if (e) FATAL("failed to create dev: '%s'", path.c_str());
-    }
-}
-
-static void do_chdir(const Cgroup::spawn_arg& arg) {
-    // chdir to a specified path
-    if (!arg.chdir_path.empty()) {
-        const string& path = arg.chdir_path;
-
-        INFO("chdir %s", path.c_str());
-        if (chdir(path.c_str())) {
-            FATAL("chdir '%s' failed", path.c_str());
-        }
-    }
-}
-
-static void do_commands(const Cgroup::spawn_arg& arg) {
-    // system commands
-    FOR_EACH(cmd, arg.cmd_list) {
-        INFO("system %s", cmd.c_str());
-        int ret = system(cmd.c_str());
-        if (ret) WARNING("system \"%s\" returns %d", cmd.c_str(), ret);
-    }
-}
-
-static void do_renice(const Cgroup::spawn_arg& arg) {
-    // nice
-    if (arg.nice) {
-        INFO("nice %d", (int)arg.nice);
-        if (nice(arg.nice) == -1) {
-            WARNING("can not set nice to %d", arg.nice);
-        }
-    }
-}
-
-static void do_set_umask(const Cgroup::spawn_arg& arg) {
-    // set umask
-    INFO("umask %d", arg.umask);
-    umask(arg.umask);
-}
-
-static void do_set_uid_gid(const Cgroup::spawn_arg& arg) {
-    // setup uid, gid
-    INFO("setgid %d, setuid %d", (int)arg.gid, (int)arg.uid);
-    if (setgid(arg.gid) || setuid(arg.uid)) {
-        // an interesting story about not checking setuid return value:
-        // https://sites.google.com/site/fullycapable/Home/thesendmailcapabilitiesissue
-        FATAL("setgid(%d) or setuid(%d) failed", (int)arg.gid, (int)arg.uid);
-    }
-}
-
-static void do_apply_rlimits(const Cgroup::spawn_arg& arg) {
-    // apply rlimit, note NPROC limit should be applied after setuid
-    FOR_EACH(p, arg.rlimits) {
-        int resource = p.first;
-        if (resource >= RLIMIT_NLIMITS) continue;
-
-        rlimit limit;
-        limit.rlim_cur = limit.rlim_max = p.second;
-
-        // wish to receive SIGXCPU or SIGXFSZ to know it is TLE or OLE.
-        // NOTE: if pid namespace is used (--isolate-process true), pid 1
-        // in the new pid ns is immune to signals (including SIGKILL) by
-        // default! This means that rlimit won't work for it. Therefore,
-        // a dummy init process is created if possible.
-        if (resource == RLIMIT_CPU || resource == RLIMIT_FSIZE) ++limit.rlim_max;
-
-        DEBUG_DO {
-            char limit_name[18];
-            switch (resource) {
-#define CONVERT_NAME(x) case x: strncpy(limit_name, # x, sizeof(limit_name)); break;
-                CONVERT_NAME(RLIMIT_CPU);
-                CONVERT_NAME(RLIMIT_FSIZE);
-                CONVERT_NAME(RLIMIT_DATA);
-                CONVERT_NAME(RLIMIT_STACK);
-                CONVERT_NAME(RLIMIT_CORE);
-                CONVERT_NAME(RLIMIT_RSS);
-                CONVERT_NAME(RLIMIT_NOFILE);
-                CONVERT_NAME(RLIMIT_AS);
-                CONVERT_NAME(RLIMIT_NPROC);
-                CONVERT_NAME(RLIMIT_MEMLOCK);
-                CONVERT_NAME(RLIMIT_LOCKS);
-                CONVERT_NAME(RLIMIT_SIGPENDING);
-                CONVERT_NAME(RLIMIT_MSGQUEUE);
-                CONVERT_NAME(RLIMIT_NICE);
-                CONVERT_NAME(RLIMIT_RTPRIO);
-                CONVERT_NAME(RLIMIT_RTTIME);
-#undef CONVERT_NAME
-                default:
-                    snprintf(limit_name, sizeof(limit_name), "0x%x", resource);
-            }
-            rlimit current;
-            getrlimit(resource, &current);
-            INFO("setrlimit %s, cur: %d => %d, max: %d => %d", limit_name,
-                 (int)current.rlim_cur, (int)limit.rlim_cur,
-                 (int)current.rlim_max, (int)limit.rlim_max);
-        }
-
-        if (setrlimit(resource, &limit)) {
-            WARNING("can not set rlimit %d", resource);
-        }
-    }
-}
-
-static void do_set_env(const Cgroup::spawn_arg& arg) {
-    // prepare env
-    if (arg.reset_env) {
-        INFO("reset ENV");
-        if (clearenv()) FATAL("can not clear env");
-    }
-
-    FOR_EACH(p, arg.env_list) {
-        const char * name = p.first.c_str();
-        const char * value = p.second.c_str();
-
-        if (setenv(name, value, 1)) FATAL("can not set env %s=%s", name, value);
-    }
-}
-
-static void do_seccomp(const Cgroup::spawn_arg& arg) {
-    // syscall whitelist
-    if (seccomp::supported() && arg.syscall_list.length() > 0) {
-        // apply seccomp, it will set PR_SET_NO_NEW_PRIVS
-        // libseccomp actually has an option to skip setting PR_SET_NO_NEW_PRIVS to 1
-        // however it makes seccomp_load error with EPERM because we just used setuid()
-        // and PR_SET_SECCOMP needs root if PR_SET_NO_NEW_PRIVS is unset.
-        INFO("applying syscall filters");
-        seccomp::Rules rules(arg.syscall_action, (uint64_t)(void*)arg.args /* special case for execve arg1 */);
-
-        if (rules.add_simple_filter(arg.syscall_list.c_str())) {
-            FATAL("failed to parse syscall filter string");
-            exit(-1);
-        }
-        if (rules.apply()) {
-            FATAL("failed to apply seccomp rules");
-            exit(-1);
-        }
-    }
-}
-
-static void do_set_new_privs(const Cgroup::spawn_arg& arg) {
-#ifndef PR_SET_NO_NEW_PRIVS
-# define PR_SET_NO_NEW_PRIVS 38
-#endif
-
-#ifndef PR_GET_NO_NEW_PRIVS
-# define PR_GET_NO_NEW_PRIVS 39
-#endif
-
-    if (arg.no_new_privs) {
-        int e = prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0);
-        if (e == -1) {
-            INFO("NO_NEW_PRIVS is not supported by kernel");
-        } else if (e == 0) {
-            INFO("prctl PR_SET_NO_NEW_PRIVS");
-            int e = prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
-            if (e) {
-                FATAL("prctl PR_SET_NO_NEW_PRIVS");
-                exit(-1);
-            }
-        }
-    }
-}
-
-static void init_signal_handler(int signal) {
-    if (signal == SIGCHLD) {
-        int status;
-        while (waitpid(-1, &status, WNOHANG) > 0);
-    } else {
-        exit(1);
-    }
-}
-
-static int clone_init_fn(void *) {
-    // a dummy init process in new pid namespace
-    // intended to be killed via SIGKILL from root pid namespace
-    prctl(PR_SET_PDEATHSIG, SIGHUP);
-
-    {
-        struct sigaction action;
-        action.sa_handler = init_signal_handler;
-        sigemptyset(&action.sa_mask);
-        action.sa_flags = 0;
-        sigaction(SIGKILL, &action, NULL);
-        sigaction(SIGHUP, &action, NULL);
-        sigaction(SIGINT, &action, NULL);
-        sigaction(SIGTERM, &action, NULL);
-        sigaction(SIGABRT, &action, NULL);
-        sigaction(SIGQUIT, &action, NULL);
-        sigaction(SIGPIPE, &action, NULL);
-        sigaction(SIGALRM, &action, NULL);
-        sigaction(SIGCHLD, &action, NULL);
-    }
-
-    // close all fds
-    {
-        list<int> fds = get_fds();
-        INFO("init is running");
-        FOR_EACH(fd, fds) close(fd);
-    }
-
-    while (1) pause();
-    return 0;
-}
-
-static int clone_main_fn(void * clone_arg) {
-    // kill us if parent dies
-    prctl(PR_SET_PDEATHSIG, SIGKILL);
-
-    // this is executed in child process after clone
-    // fs and uid settings should be done here
-    Cgroup::spawn_arg& arg = *(Cgroup::spawn_arg*)clone_arg;
-
-#ifdef SYSCTL_PER_NS_WORKS
-    // NOTE: Do not uncomment this until sysctl per namespace works.
-    // current kernel use global variables for vm.oom_kill_allocating_task,
-    // etc.
-    do_set_sysctl();
-#endif
-    do_set_uts(arg);
-    do_set_netns(arg);
-    do_process_fds(arg);
-    do_privatize_filesystem(arg);
-    do_umount_outside_chroot(arg);
-    do_mount_proc(arg);
-    do_hide_sensitive(arg);
-    do_mount_bindfs(arg);
-    do_remounts(arg);
-    do_chroot(arg);
-    do_mount_tmpfs(arg);
-    do_remount_dev(arg);
-    do_chdir(arg);
-    do_commands(arg);
-    do_set_umask(arg);
-    do_set_uid_gid(arg);
-    do_apply_rlimits(arg);
-    do_set_env(arg);
-    do_renice(arg);
-    do_set_new_privs(arg);
-
-    // all prepared! blocking, wait for parent
-    INFO("waiting for parent");
-    char buf[4];
-    int ret = read(arg.sockets[0], buf, sizeof buf);
-    (void)ret;
-
-    // let parent know we got the message, parent then can close fd without SIGPIPE child
-    INFO("got from parent: '%3s'. notify parent", buf);
-    strncpy(buf, "PRE", sizeof buf);
-    ret = write(arg.sockets[0], buf, sizeof buf);
-    (void)ret;
-
-    // not closing sockets[0] here, it will closed on exec
-    // if exec fails, it will be closed upon process exit (aka. this function returns)
-    fd_set_cloexec(arg.sockets[0]);
-
-    // it's time for callback, write log first because fanotify may block us from
-    // doing that
-    int callback_ret = 0;
-    if (arg.callback_child) {
-        INFO("will run callback and execvp %s ...", arg.args[0]);
-        callback_ret = arg.callback_child((void *) &arg);
-    } else {
-        INFO("will execvp %s ...", arg.args[0]);
-    }
-
-    if (callback_ret == 0) {
-        // exec target. syscall filter must be done just before execve because we need other
-        // syscalls in above code.
-        do_seccomp(arg);
-        execvp(arg.args[0], arg.args);
-        // if exec fails, write reason down (child knows more details than parent)
-        ERROR("exec '%s' failed", arg.args[0]);
-    }
-
-    // exec or callback failed
-    // notify parent that exec failed
-    strncpy(buf, "ERR", sizeof buf);
-    ret = write(arg.sockets[0], buf, sizeof buf);
-    (void)ret;
-
-    // wait parent
-    ret = read(arg.sockets[0], buf, sizeof buf);
-    (void)ret;
-
-    return -1;
-} // clone_main_fn
-
-static int is_setns_pidns_supported() {
-    string pidns_path = string(fs::PROC_PATH) + "/self/ns/pid";
-    int fd = open(pidns_path.c_str(), O_RDONLY);
-    if (fd == -1) return 0;
-    close(fd);
-    return 1;
-}
-
-#ifndef NDEBUG
-static string clone_flags_to_str(int clone_flags) {
-    int v = clone_flags;
-    string s;
-#define TEST_FLAG(x) if ((v & x) != 0) { s += string(# x) + " | "; v ^= x; }
-    TEST_FLAG(CLONE_VM);
-    TEST_FLAG(CLONE_FS);
-    TEST_FLAG(CLONE_FILES);
-    TEST_FLAG(CLONE_SIGHAND);
-    TEST_FLAG(CLONE_PTRACE);
-    TEST_FLAG(CLONE_VFORK);
-    TEST_FLAG(CLONE_PARENT);
-    TEST_FLAG(CLONE_THREAD);
-    TEST_FLAG(CLONE_NEWNS);
-    TEST_FLAG(CLONE_SYSVSEM);
-    TEST_FLAG(CLONE_SETTLS);
-    TEST_FLAG(CLONE_PARENT_SETTID);
-    TEST_FLAG(CLONE_CHILD_CLEARTID);
-    TEST_FLAG(CLONE_DETACHED);
-    TEST_FLAG(CLONE_UNTRACED);
-    TEST_FLAG(CLONE_CHILD_SETTID);
-    TEST_FLAG(CLONE_NEWUTS);
-    TEST_FLAG(CLONE_NEWIPC);
-    TEST_FLAG(CLONE_NEWUSER);
-    TEST_FLAG(CLONE_NEWPID);
-    TEST_FLAG(CLONE_NEWNET);
-    TEST_FLAG(CLONE_IO);
-    TEST_FLAG(SIGCHLD);
-
-    TEST_FLAG(SIGINT);
-    TEST_FLAG(SIGQUIT);
-    TEST_FLAG(SIGILL);
-    TEST_FLAG(SIGTRAP);
-    TEST_FLAG(SIGABRT);
-    TEST_FLAG(SIGIOT);
-    TEST_FLAG(SIGBUS);
-    TEST_FLAG(SIGFPE);
-    TEST_FLAG(SIGKILL);
-    TEST_FLAG(SIGUSR1);
-    TEST_FLAG(SIGSEGV);
-    TEST_FLAG(SIGUSR2);
-    TEST_FLAG(SIGPIPE);
-    TEST_FLAG(SIGALRM);
-    TEST_FLAG(SIGTERM);
-    TEST_FLAG(SIGSTKFLT);
-    TEST_FLAG(SIGCLD);
-    TEST_FLAG(SIGCHLD);
-    TEST_FLAG(SIGCONT);
-    TEST_FLAG(SIGSTOP);
-    TEST_FLAG(SIGTSTP);
-    TEST_FLAG(SIGTTIN);
-    TEST_FLAG(SIGTTOU);
-    TEST_FLAG(SIGURG);
-    TEST_FLAG(SIGXCPU);
-    TEST_FLAG(SIGXFSZ);
-    TEST_FLAG(SIGVTALRM);
-    TEST_FLAG(SIGPROF);
-    TEST_FLAG(SIGWINCH);
-    TEST_FLAG(SIGPOLL);
-    TEST_FLAG(SIGIO);
-    TEST_FLAG(SIGPWR);
-    TEST_FLAG(SIGSYS);
-#ifdef SIGUNUSED
-    TEST_FLAG(SIGUNUSED);
-#endif
-#undef TEST_FLAG
-    if (v) {
-        s += strconv::from_long((long)v);
-    } else {
-        s = s.substr(0, s.length() - 3);
-    }
-    return s;
-}
-#endif
-
-pid_t Cgroup::spawn(spawn_arg& arg) {
-    // uid and gid should > 0
-    if (arg.uid <= 0 || arg.gid <= 0) {
-        WARNING("uid and gid can not <= 0. spawn rejected");
-        return -2;
-    }
-
-    // stack size for cloned processes
-    long stack_size = sysconf(_SC_PAGESIZE);
-    static const long MIN_STACK_SIZE = 8192;
-    if (stack_size < MIN_STACK_SIZE) stack_size = MIN_STACK_SIZE;
-
-    // We need root permissions and drop root later, no CLONE_NEWUSER here
-    // CLONE_NEWNS is required for private mounts
-    // CLONE_NEWUSER is not used because new uid 0 may be non-root
-    int clone_flags = CLONE_NEWNS | SIGCHLD | arg.clone_flags;
-
-    // older kernel (ex. Debian 7, 3.2.0) doesn't support setns(whatever, CLONE_PIDNS)
-    // just do not create init process in that case.
-    if (is_setns_pidns_supported() && (clone_flags & CLONE_NEWPID) == CLONE_NEWPID) {
-        // create a dummy init process in a new namespace
-        // CLONE_PTRACE: prevent the process being traced by another process
-        INFO("spawning dummy init process");
-        int init_clone_flags = CLONE_NEWPID;
-        init_pid_ = clone(clone_init_fn, (void*)((char*)alloca(stack_size) + stack_size), init_clone_flags, &arg);
-        if (init_pid_ < 0) {
-            ERROR("can not spawn init process");
-            return -3;
-        }
-
-        // switch to that pid namespace for our next clone
-        string pidns_path = string(fs::PROC_PATH) + "/" + strconv::from_ulong((unsigned long)init_pid_) + "/ns/pid";
-        INFO("set pid ns to %s", pidns_path.c_str());
-        int pidns_fd = open(pidns_path.c_str(), O_RDONLY);
-        if (pidns_fd < 0) {
-            ERROR("can not open pid namespace");
-            return -3;
-        }
-
-        // older glibc does not have setns
-        if (syscall(SYS_setns, pidns_fd, CLONE_NEWPID)) {
-            ERROR("can not set pid namespace");
-            return -3;
-        };
-        close(pidns_fd);
-
-        // remove CLONE_NEWPID flag because setns() will affect all new processes
-        clone_flags ^= CLONE_NEWPID;
-    } // spawn init process
-
-    DEBUG_DO {
-        INFO("clone flags = 0x%x = %s", (int)clone_flags, clone_flags_to_str(clone_flags).c_str());
-    }
-
-    // do sync use socket pair
-    if (socketpair(AF_LOCAL, SOCK_STREAM, 0, arg.sockets)) {
-        ERROR("socketpair failed");
-        return -1;
-    }
-
-    // sockets fds should expire when exec
-    fd_set_cloexec(arg.sockets[0]);
-    fd_set_cloexec(arg.sockets[1]);
-
-    pid_t child_pid;
-    child_pid = clone(clone_main_fn, (void*)((char*)alloca(stack_size) + stack_size), clone_flags, &arg);
-    char buf[4];
-    ssize_t ret;
-
-    if (child_pid < 0) {
-        FATAL("clone failed");
-        goto cleanup;
-    }
-
-    INFO("child pid = %lu", (unsigned long)child_pid);
-
-    // attach child to current cgroup. cpu and memory
-    // resource counter start to work from here
-    INFO("attach %lu", (unsigned long)child_pid);
-    attach(child_pid);
-
-    // child is blocking, waiting us before exec
-    // it's time to let the child go
-    strncpy(buf, "RUN", sizeof buf);
-    close(arg.sockets[0]);
-    ret = send(arg.sockets[1], buf, sizeof buf, MSG_NOSIGNAL);
-    if (ret < 0) {
-        WARNING("can not send let-go message to child");
-        goto cleanup;
-    }
-
-    // wait for child response
-    INFO("reading from child");
-
-    buf[0] = 0;
-    ret = read(arg.sockets[1], buf, sizeof buf);
-
-    INFO("from child, got '%3s'", buf);
-    if (buf[0] != 'P' || ret <= 0) {  // excepting "PRE"
-        // child has problem to start
-        child_pid = -3;
-        goto cleanup;
-    }
-
-    // child exec may fail, confirm
-    if (read(arg.sockets[1], buf, sizeof buf) > 0 && buf[0] == 'E') {  // "ERR"
-        INFO("seems child exec failed");
-        child_pid = -4;
-        goto cleanup;
-    }
-
-    // the child has exec successfully
-    // disable oom killer because it will make dmesg noisy.
-    // Note: a process can enter D (uninterruptable sleep) status
-    // when oom killer disabled, killing it requires re-enable oom killer
-    // or enlarge memory limit
-//    INFO("disabling oom killer");
-//    if (set(CG_MEMORY, "memory.oom_control", "1\n")) INFO("can not set memory.oom_control");
-
-    cleanup:
-    close(arg.sockets[1]);
-    return child_pid;
-}
-#endif

--- a/src/cgroup.cc
+++ b/src/cgroup.cc
@@ -36,13 +36,14 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <climits>
 #include "cgroup.h"
 #include "utils/linux_only.h"
 #include "utils/for_each.h"
 #include "utils/fs.h"
 #include "utils/strconv.h"
 
-
+#ifdef CGROUP_V1
 using namespace lrun;
 
 using std::string;
@@ -367,6 +368,7 @@ int Cgroup::attach(pid_t pid) {
     int ret = 0;
     for (int id = 0; id < SUBSYS_COUNT; ++id) {
         string path = subsys_path((subsys_id_t)id);
+        // FIXME: It seems pid should be write into /cgroup.procs and tid should be write into /tasks
         ret |= fs::write(path + "/tasks", pidbuf);
     }
 
@@ -1231,4 +1233,1164 @@ cleanup:
     close(arg.sockets[1]);
     return child_pid;
 }
+#endif
 
+#ifdef CGROUP_V2
+using namespace lrun;
+
+using std::string;
+using std::list;
+
+//const char Cgroup::subsys_names[4][8] = {
+//        "cgroup",
+//        "cpu",
+//        "memory",
+//        "devices",
+//};
+
+static struct {
+    const char *name;
+    unsigned int minor;
+    // major is missing because all basic_devices have major = 1
+} basic_devices[] = {
+        {"null", 3},
+        {"zero", 5},
+        {"full", 7},
+        {"random", 8},
+        {"urandom", 9},
+};
+
+//std::string Cgroup::subsys_base_paths_[sizeof(subsys_names) / sizeof(subsys_names[0])];
+//
+//int Cgroup::subsys_id_from_name(const char * const name) {
+//    for (size_t i = 0; i < sizeof(Cgroup::subsys_names) / sizeof(Cgroup::subsys_names[0]); ++i) {
+//        if (strcmp(name, subsys_names[i]) == 0) return i;
+//    }
+//    return -1;
+//}
+
+string Cgroup::base_path(bool create_on_need) {
+
+    const char * const MNT_SRC_NAME = "cgroup_lrun";
+    const char * MNT_DEST_BASE_PATH = "/sys/fs/cgroup";
+
+    std::map<string, fs::MountEntry> mounts = fs::get_mounts();
+    FOR_EACH_CONST(p, mounts) {
+        const fs::MountEntry& ent = p.second;
+        if (ent.type != string(fs::TYPE_CGROUP2)) continue;
+        return ent.dir;
+    }
+
+    // no cgroups mounted, prepare one
+    if (!create_on_need) return "";
+
+    if (!fs::is_dir(MNT_DEST_BASE_PATH)) {
+        // no /sys/fs/cgroup in system, try conservative location
+        MNT_DEST_BASE_PATH = "/cgroup";
+        mkdir(MNT_DEST_BASE_PATH, 0700);
+    }
+
+    // create and mount cgroup at dest_path
+    string dest_path = string(MNT_DEST_BASE_PATH);
+    INFO("mkdir and mounting '%s'", dest_path.c_str());
+    mkdir(dest_path.c_str(), 0700);
+    // TODO: there should be additional flag: nsdelegate,memory_recursiveprot
+    // I don't know whether it is correct putting them in data.
+    int e = mount(MNT_SRC_NAME, dest_path.c_str(), fs::TYPE_CGROUP2, MS_NOEXEC | MS_NOSUID | MS_RELATIME | MS_NODEV, "nsdelegate,memory_recursiveprot");
+
+    if (e != 0) {
+        int last_err = errno;
+        errno = last_err;
+        FATAL("can not mount cgroup v2 '%s'", dest_path.c_str());
+    }
+    return dest_path;
+}
+
+string Cgroup::path_from_name(const string& name) {
+    return base_path() + "/" + name;
+}
+
+string Cgroup::group_path() const {
+    return path_from_name(name_);
+}
+
+int Cgroup::exists(const string& name) {
+    if (!fs::is_dir(path_from_name(name))) return false;
+    return true;
+}
+
+Cgroup Cgroup::create(const string& name) {
+    Cgroup cg;
+
+    if (exists(name)) {
+        INFO("create cgroup '%s': already exists", name.c_str());
+        cg.name_ = name;
+        return cg;
+    }
+
+    int success = 1;
+
+    string path = path_from_name(name);
+    if (mkdir(path.c_str(), 0700)) {
+        ERROR("mkdir '%s': failed", path.c_str());
+        success = 0;
+    }
+
+    if (success) cg.name_ = name;
+    cg.init_pid_ = 0;
+
+    return cg;
+}
+
+Cgroup::Cgroup() { }
+
+bool Cgroup::valid() const {
+    return !name_.empty() && exists(name_);
+}
+
+void Cgroup::update_output_count() {
+    if (!valid()) return;
+    string procs_path = group_path() + "/cgroup.procs";
+
+    if (fs::read(procs_path, 4).empty()) return;
+
+    FILE * procs = fopen(procs_path.c_str(), "r");
+    char spid[26]; // sizeof(pid_t) * 3 + 2, assuming sizeof(pid_t) is 8
+    while (fscanf(procs, "%25s", spid) == 1) {
+        unsigned long pid;
+        unsigned long long bytes = 0;
+        if (sscanf(spid, "%lu", &pid) == 0) continue;
+        FILE * io = fopen((string(fs::PROC_PATH) + "/" + spid + "/io").c_str(), "r");
+        if (!io) continue;
+        int res = 0;
+        res = fscanf(io, "rchar: %*s\nwchar: %Lu", &bytes);
+        if (res == 1) {
+            if (output_counter_[pid] < bytes) output_counter_[pid] = bytes;
+        }
+        fclose(io);
+    }
+    fclose(procs);
+}
+
+long long Cgroup::output_usage() const {
+    long long bytes = 0;
+    FOR_EACH_CONST(p, output_counter_) {
+        bytes += p.second;
+    }
+    return bytes;
+}
+
+list<pid_t> Cgroup::get_pids() {
+    string procs_path = group_path() + "/cgroup.procs";
+    FILE * procs = fopen(procs_path.c_str(), "r");
+    list<pid_t> pids;
+    if (procs) {
+        unsigned long pid;
+        while (fscanf(procs, "%lu", &pid) == 1) pids.push_back((pid_t)pid);
+        fclose(procs);
+    }
+    return pids;
+}
+
+bool Cgroup::has_pid(pid_t pid) {
+    bool result = false;
+
+    char path[sizeof(long) * 3 + sizeof("/proc//cgroup")];
+    snprintf(path, sizeof(path), "/proc/%ld/cgroup", (long)pid);
+    FILE *fp = fopen(path, "r");
+    if (!fp) return false;
+
+    size_t len = 0;
+    char *line = NULL;
+    char buf[64];  // FIXME cgroup name is 63 chars long
+    while (getline(&line, &len, fp) != -1) {
+        // the line should look like:
+        // 0::/cgname
+        if (sscanf(line, "%*d::/%63s", buf) != 1)
+            continue;
+        result = (strncmp(name_.c_str(), buf, sizeof(buf)) == 0);
+        break;
+    }
+    if (line) free(line);
+    fclose(fp);
+    return result;
+}
+
+static const useconds_t LOOP_ITERATION_INTERVAL = 10000;  // 10 ms
+
+int Cgroup::freeze(bool freeze, int timeout) {
+    if (!valid()) return -1;
+    string freeze_state_path = group_path() + "/cgroup.freeze";
+
+    if (!freeze) {
+        INFO("unfreeze");
+        fs::write(freeze_state_path, "0\n");
+    } else {
+        INFO("freezing");
+        fs::write(freeze_state_path, "1\n");
+
+        for (;;) {
+            int frozen = (strncmp(fs::read(freeze_state_path, 4).c_str(), "1", 3) == 0);
+            if (frozen) break;
+
+            timeout--;
+            if (timeout <= 0) {
+                INFO("giving up, not frozen");
+                return -2;
+            }
+
+            usleep(LOOP_ITERATION_INTERVAL);
+        }
+        INFO("confirmed frozen");
+    }
+    return 0;
+}
+
+int Cgroup::empty() {
+    string procs_path = group_path() + "/cgroup.procs";
+    return fs::read(procs_path, 4).empty() ? 1 : 0;
+}
+
+void Cgroup::killall(bool confirm) {
+    // The init pid can be outside the cgroup task list. Therefore do not
+    // test "empty()" here.
+    if (!valid()) return;
+
+    if (init_pid_) {
+        if (init_pid_ > 0) {
+            // if init pid exists, just kill it and the kernel will kill all
+            // remaining processes in the same pid ns.
+            // because our init process (clone_init_fn) won't allocate memory,
+            // it will not enter D state and is safe to kill.
+            kill(init_pid_, SIGKILL);
+            // cancel memory limit. this will wake up some D state processes,
+            // which are allocating memory and reached memory limit.
+            set_memory_limit(-1);
+            INFO("sent SIGKILL to init process %lu", (unsigned long)init_pid_);
+            init_pid_ = -1;
+        }
+
+        if (confirm) {
+            // wait and confirm that processes are gone
+            for (int clear = 0; clear == 0;) {
+                if (!valid() || empty()) break;
+                usleep(LOOP_ITERATION_INTERVAL);
+            }
+        }
+    } else {
+        // legacy (unreliable) way to kill processes, or not using a pid
+        // namespace
+        while (valid() && !empty()) {
+            freeze(true, 2);
+            list<pid_t> pids = get_pids();
+            FOR_EACH(p, pids) kill(p, SIGKILL);
+            INFO("sent SIGKILLs to %lu processes", (unsigned long)pids.size());
+            if (!confirm) break;
+            freeze(false, 1);
+            if (!empty()) usleep(LOOP_ITERATION_INTERVAL);
+        }
+    }
+
+    return;
+}
+
+int Cgroup::destroy() {
+    killall();
+
+    int ret = 0;
+    if (fs::is_dir(group_path())) ret |= rmdir(group_path().c_str());
+
+    return ret;
+}
+
+int Cgroup::set(const string& property, const string& value) {
+    INFO("set cgroup %s to %s", property.c_str(), value.c_str());
+    return fs::write(group_path() + "/" + property, value);
+}
+
+string Cgroup::get(const string& property, size_t max_length) const {
+    return fs::read(group_path() + "/" + property, max_length);
+}
+
+int Cgroup::inherit(const string& property) {
+    string value = fs::read(base_path(false) + "/" + property);
+    return fs::write(group_path() + "/" + property, value);
+}
+
+int Cgroup::attach(pid_t pid) {
+    char pidbuf[32];
+    snprintf(pidbuf, sizeof(pidbuf), "%lu\n", (unsigned long)pid);
+
+    int ret = 0;
+    ret |= fs::write(group_path() + "/cgroup.procs", pidbuf);
+
+    return ret;
+}
+
+int Cgroup::limit_devices() {
+    int e = 0;
+    // TODO: implement
+//    e += set(CG_DEVICES, "devices.deny", "a");
+//    for (size_t i = 0; i < sizeof(basic_devices) / sizeof(basic_devices[0]); ++i) {
+//        long minor = basic_devices[i].minor;
+//        string v = string("c 1:" + strconv::from_long(minor) + " rwm");
+//        e += set(CG_DEVICES, "devices.allow", v);
+//    }
+    return e ? -1 : 0;
+}
+
+int Cgroup::reset_usages() {
+    int e = 0;
+    // FIXME: maybe not available in v2
+//    e += set(CG_CPUACCT, "cpuacct.usage", "0");
+//    e += set(CG_MEMORY, "memory.max_usage_in_bytes", "0") * set(CG_MEMORY, "memory.memsw.max_usage_in_bytes", "0");
+//    output_counter_.clear();
+    return e ? -1 : 0;
+}
+
+int Cgroup::reset_cpu_usage() {
+    int e = 0;
+    // FIXME: maybe not available in v2
+//    e = set(CG_CPUACCT, "cpuacct.usage", "0");
+    return e ? -1 : 0;
+}
+
+double Cgroup::cpu_usage() const {
+    char cpu_usage[32];
+    string content = get("cpu.stat", 32);
+    if (sscanf(content.c_str(), "usage_usec %31s", cpu_usage) == 0) {
+        return 0.0;
+    }
+    // convert from useconds(microseconds) to seconds
+    return strconv::to_double(cpu_usage) / 1e6;
+}
+
+long long Cgroup::memory_current() const {
+    string usage = get("memory.current");
+//    string swap_usage = get("memory.swap.current");
+    return strconv::to_longlong(usage);
+//    return strconv::to_longlong(memory_usage) + strconv::to_longlong(swap_usage)
+}
+
+long long Cgroup::memory_peak() const {
+    string usage = get("memory.peak");
+    return strconv::to_longlong(usage);
+}
+
+long long Cgroup::memory_limit() const {
+    string limit = get("memory.max");
+    if (strcmp(limit.c_str(), "max") == 0) return LLONG_MAX;
+//    if (limit.empty()) limit = get(CG_MEMORY, "memory.limit_in_bytes");
+    return strconv::to_longlong(limit);
+}
+
+bool Cgroup::is_under_oom() const {
+    string content = get( "memory.events");
+    string sub_content = content.substr(content.find("oom "));
+    int count;
+    if (sscanf(sub_content.c_str(), "oom %d", &count) == 0) return false;
+    return count > 0;
+}
+
+long long Cgroup::set_memory_limit(long long bytes) {
+    int e = 1;
+
+    if (bytes <= 0) {
+        // read base (parent) cgroup properties
+        e *= inherit("memory.max");
+    } else {
+        e *= set("memory.max", strconv::from_longlong(bytes));
+    }
+
+    if (e) {
+        return -1;
+    } else {
+        // The kernel might "adjust" the memory limit. Read it back.
+        string limit = get("memory.max");
+        return strconv::to_longlong(limit);
+    }
+}
+
+// following functions are called by clone_main_fn
+
+__attribute__((unused)) static void do_set_sysctl() {
+    INFO("set sysctl settings");
+    // skip slow oom scaning and do not write syslog
+    fs::write("/proc/sys/vm/oom_kill_allocating_task", "1\n");
+    fs::write("/proc/sys/vm/oom_dump_tasks", "0\n");
+    // block dmesg access
+    fs::write("/proc/sys/kernel/dmesg_restrict", "1\n");
+}
+
+static void do_privatize_filesystem(__attribute__((unused)) const Cgroup::spawn_arg& arg) {
+    // make sure filesystem not be shared
+    // ignore this step for old systems without these features
+    int type = MS_PRIVATE | MS_REC;
+    if (type && fs::mount_set_shared("/", MS_PRIVATE | MS_REC)) {
+        FATAL("can not mount --make-rprivate /");
+    }
+}
+
+static void do_remounts(const Cgroup::spawn_arg& arg) {
+    FOR_EACH(p, arg.remount_list) {
+        const string& dest = p.first;
+        unsigned long flags = p.second;
+        // tricky point: if the original mount point has --bind, remount with --bind
+        // can make it less likely to get "device busy" message
+        if (arg.bindfs_dest_set.count(dest)) flags |= MS_BIND;
+
+        INFO("remount %s", dest.c_str());
+        for (;;) {
+            if (fs::remount(dest, flags) == 0) break;
+            if (flags & MS_BIND) FATAL("remount '%s' failed", dest.c_str());
+            flags |= MS_BIND;
+        }
+    }
+}
+
+static void do_mount_bindfs(const Cgroup::spawn_arg& arg) {
+    // bind fs mounts
+    FOR_EACH(p, arg.bindfs_list) {
+        const string& dest = p.first;
+        const string& src = p.second;
+
+        INFO("mount bind %s -> %s", src.c_str(), dest.c_str());
+        if (fs::mount_bind(src, dest)) {
+            FATAL("mount bind '%s' -> '%s' failed", src.c_str(), dest.c_str());
+        }
+    }
+}
+
+static void do_chroot(const Cgroup::spawn_arg& arg) {
+    // chroot to a prepared place
+    if (!arg.chroot_path.empty()) {
+        const string& path = arg.chroot_path;
+
+        INFO("chroot %s", path.c_str());
+        if (chroot(path.c_str())) {
+            FATAL("chroot '%s' failed", path.c_str());
+        }
+    }
+}
+
+static void do_umount_outside_chroot(const Cgroup::spawn_arg& arg) {
+    if (!arg.umount_outside) return;
+    if (arg.chroot_path.empty()) return;
+
+    std::map<string, fs::MountEntry> mounts = fs::get_mounts();
+    list<string> umount_list;
+    FOR_EACH(p, mounts) {
+        const string& dest = p.second.dir;
+        if (arg.chroot_path.substr(0, dest.length()) == dest) continue;
+        if (dest.substr(0, arg.chroot_path.length()) == arg.chroot_path) continue;
+        umount_list.push_front(dest);
+    }
+
+    // umount in reversed order
+    FOR_EACH(dest, umount_list) {
+        INFO("umount %s", dest.c_str());
+        if (umount2(dest.c_str(), MNT_DETACH) == -1) {
+            WARNING("cannot umount %s", dest.c_str());
+        }
+    }
+}
+
+static bool should_mount_proc(const Cgroup::spawn_arg& arg) {
+    if (!fs::is_accessible(fs::join(arg.chroot_path, fs::PROC_PATH), X_OK)) return false;
+    return (arg.clone_flags & CLONE_NEWPID) != 0 || !arg.chroot_path.empty();
+}
+
+static bool should_hide_sensitive(const Cgroup::spawn_arg& arg) {
+    if (!should_mount_proc(arg)) return false;
+
+    // currently there is no option about this behavior
+    // when `--no-new-privs false`, the user does not want to hide anything
+    if (!arg.no_new_privs) return false;
+    if (getenv("LRUN_DO_NOT_HIDE_SENSITIVE")) return false;
+    return true;
+}
+
+static const char * get_proc_fs_type(const Cgroup::spawn_arg& arg) {
+    // use "liteproc" when possible
+    static const char proc_fs[] = "proc";
+    static const char liteproc_fs[] = "liteproc";
+    // when `--no-new-privs false`, the user does not want to hide anything
+    if (!arg.no_new_privs) return proc_fs;
+    // 4KB is probably enough for /proc/filesystems.
+    // on my system, it is 398 bytes now.
+    if (fs::read("/proc/filesystems", 4095).find("liteproc") == string::npos) {
+        return proc_fs;
+    } else {
+        return liteproc_fs;
+    }
+}
+
+static void do_mount_proc(const Cgroup::spawn_arg& arg) {
+    // mount /proc if pid namespace is enabled and the directory exists
+    if (!should_mount_proc(arg)) return;
+    string dest = fs::join(arg.chroot_path, fs::PROC_PATH);
+    INFO("mount procfs at %s", dest.c_str());
+    const char * mount_opts = should_hide_sensitive(arg) ? "hidepid=2" : NULL;
+    if (mount(NULL, dest.c_str(), get_proc_fs_type(arg), MS_NOEXEC | MS_NOSUID, mount_opts)) {
+        FATAL("mount procfs failed");
+    }
+}
+
+static void do_hide_sensitive(const Cgroup::spawn_arg& arg) {
+    if (!should_hide_sensitive(arg)) return;
+    string proc_sys_path = fs::join(arg.chroot_path, "/proc/sys");
+    if (fs::is_accessible(proc_sys_path, X_OK)) {
+        mount(NULL, proc_sys_path.c_str(), "tmpfs", MS_NOSUID | MS_RDONLY, "size=0");
+    }
+}
+
+static list<int> get_fds() {
+    list<int> fds;
+
+    struct dirent **namelist = 0;
+    int nlist = scandir("/proc/self/fd", &namelist, 0, alphasort);
+    for (int i = 0; i < nlist; ++i) {
+        const char * name = namelist[i]->d_name;
+        // skip . and ..
+        if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0) {
+            int fd = -1;
+            if (sscanf(name, "%d", &fd) != 1) continue;
+            // scandir will use a dirfd. verify existance of fds
+            if (fs::is_fd_valid(fd))
+                fds.push_back(fd);
+        }
+        free(namelist[i]);
+    }
+    if (namelist) free(namelist);
+
+    return fds;
+}
+
+static void do_set_uts(const Cgroup::spawn_arg& arg) {
+    int e;
+    if (!arg.uts.domainname.empty()) {
+        INFO("setdomainname: %s", arg.uts.domainname.c_str());
+        e = setdomainname(arg.uts.domainname.c_str(), arg.uts.domainname.length());
+        if (e == -1) {
+            FATAL("setdomainname '%s' failed", arg.uts.domainname.c_str());
+            exit(-1);
+        }
+    }
+    if (!arg.uts.nodename.empty()) {
+        INFO("sethostname: %s", arg.uts.nodename.c_str());
+        e = sethostname(arg.uts.nodename.c_str(), arg.uts.nodename.length());
+        if (e == -1) {
+            FATAL("sethostname '%s' failed", arg.uts.nodename.c_str());
+            exit(-1);
+        }
+    }
+
+    // [[[cog
+    //  import cog
+    //  opts = {'release': 'osrelease', 'sysname': 'ostype', 'version': 'version'}
+    //  for opt, name in opts.items():
+    //    cog.out('''
+    //      if (!arg.uts.%(opt)s.empty() && fs::is_accessible("/proc/sys/utsmod/%(name)s"), W_OK) {
+    //          fs::write("/proc/sys/utsmod/%(name)s", arg.uts.%(opt)s);
+    //      }''' % {'name': name, 'opt': opt}, trimblanklines=True)
+    // ]]]
+    if (!arg.uts.release.empty() && fs::is_accessible("/proc/sys/utsmod/osrelease"), W_OK) {
+        fs::write("/proc/sys/utsmod/osrelease", arg.uts.release);
+    }
+    if (!arg.uts.sysname.empty() && fs::is_accessible("/proc/sys/utsmod/ostype"), W_OK) {
+        fs::write("/proc/sys/utsmod/ostype", arg.uts.sysname);
+    }
+    if (!arg.uts.version.empty() && fs::is_accessible("/proc/sys/utsmod/version"), W_OK) {
+        fs::write("/proc/sys/utsmod/version", arg.uts.version);
+    }
+    // [[[end]]]
+}
+
+static void do_set_netns(const Cgroup::spawn_arg& arg) {
+    if (arg.netns_fd == -1) return;
+
+    INFO("set netns")
+
+    // older glibc does not have setns
+    if (syscall(SYS_setns, arg.netns_fd, CLONE_NEWNET)) {
+        FATAL("can not set netns");
+    };
+}
+
+static void do_fd_redirect(int fd_dst, int fd_src) {
+    if (fd_src >= 0 && fd_src != fd_dst) {
+        INFO("dup2 %d %d", fd_src, fd_dst);
+        int ret = dup2(fd_src, fd_dst);
+        if (ret == -1) {
+            FATAL("cannot dup %d", fd_src);
+        }
+    }
+}
+
+static void fd_set_cloexec(int fd, int enforce = 1) {
+    if (fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) | FD_CLOEXEC)) {
+        if (enforce) {
+            FATAL("fcntl %d failed", fd);
+        } else {
+            // fd can become invalid across namespaces
+            close(fd);
+        }
+    }
+}
+
+static void do_process_fds(const Cgroup::spawn_arg& arg) {
+    // this is for parent process
+    close(arg.sockets[1]);
+
+#ifndef NDEBUG
+    // make a copy of log fd because we may soon lose stderr
+    // this affects INFO, WARN, ERROR, FATAL
+    int flog_fd = dup(STDERR_FILENO);
+    flog = fdopen(flog_fd, "a");
+#endif
+
+    do_fd_redirect(STDOUT_FILENO, arg.stdout_fd);
+    do_fd_redirect(STDERR_FILENO, arg.stderr_fd);
+
+    INFO("applying FD_CLOEXEC");
+    list<int> fds = get_fds();
+    FOR_EACH(fd, fds) {
+        if (fd != STDERR_FILENO && fd != STDIN_FILENO && fd != STDOUT_FILENO
+            && arg.keep_fds.count(fd) == 0) {
+            fd_set_cloexec(fd, 0 /* close that fd on error */);
+        }
+    }
+}
+
+static void do_mount_tmpfs(const Cgroup::spawn_arg& arg) {
+    // setup other tmpfs mounts
+    FOR_EACH(p, arg.tmpfs_list) {
+        const char * dest = p.first.c_str();
+        const long long& size = p.second;
+
+        INFO("mount tmpfs %s (size = %lld kB)", dest, size);
+
+        int e = 0;
+        if (size <= 0) {
+            // treat as read-only
+            e = mount(NULL, dest, "tmpfs", MS_NOSUID | MS_RDONLY, "size=0");
+        } else {
+            e = mount(NULL, dest, "tmpfs", MS_NOSUID, ((string)("mode=0777,size=" + strconv::from_longlong(size))).c_str());
+        }
+        if (e) {
+            FATAL("mount tmpfs '%s' failed", dest);
+        }
+    }
+}
+
+static void do_remount_dev(const Cgroup::spawn_arg& arg) {
+    if (!arg.remount_dev) return;
+
+    INFO("remount /dev");
+
+    int e;
+    // mount a minimal tmpfs to /dev
+    e = mount(NULL, "/dev", "tmpfs", MS_NOSUID, "size=64,mode=0755,uid=0,gid=0");
+    if (e) FATAL("remount /dev failed");
+
+    // create basic devices
+    for (size_t i = 0; i < sizeof(basic_devices) / sizeof(basic_devices[0]); ++i) {
+        string path = string("/dev/") + basic_devices[i].name;
+        unsigned int minor = basic_devices[i].minor;
+        e = mknod(path.c_str(), S_IFCHR | 0666 /* mode */, makedev(1 /* major */, minor));
+        if (!e) e = chmod(path.c_str(), 0666);
+        if (e) FATAL("failed to create dev: '%s'", path.c_str());
+    }
+}
+
+static void do_chdir(const Cgroup::spawn_arg& arg) {
+    // chdir to a specified path
+    if (!arg.chdir_path.empty()) {
+        const string& path = arg.chdir_path;
+
+        INFO("chdir %s", path.c_str());
+        if (chdir(path.c_str())) {
+            FATAL("chdir '%s' failed", path.c_str());
+        }
+    }
+}
+
+static void do_commands(const Cgroup::spawn_arg& arg) {
+    // system commands
+    FOR_EACH(cmd, arg.cmd_list) {
+        INFO("system %s", cmd.c_str());
+        int ret = system(cmd.c_str());
+        if (ret) WARNING("system \"%s\" returns %d", cmd.c_str(), ret);
+    }
+}
+
+static void do_renice(const Cgroup::spawn_arg& arg) {
+    // nice
+    if (arg.nice) {
+        INFO("nice %d", (int)arg.nice);
+        if (nice(arg.nice) == -1) {
+            WARNING("can not set nice to %d", arg.nice);
+        }
+    }
+}
+
+static void do_set_umask(const Cgroup::spawn_arg& arg) {
+    // set umask
+    INFO("umask %d", arg.umask);
+    umask(arg.umask);
+}
+
+static void do_set_uid_gid(const Cgroup::spawn_arg& arg) {
+    // setup uid, gid
+    INFO("setgid %d, setuid %d", (int)arg.gid, (int)arg.uid);
+    if (setgid(arg.gid) || setuid(arg.uid)) {
+        // an interesting story about not checking setuid return value:
+        // https://sites.google.com/site/fullycapable/Home/thesendmailcapabilitiesissue
+        FATAL("setgid(%d) or setuid(%d) failed", (int)arg.gid, (int)arg.uid);
+    }
+}
+
+static void do_apply_rlimits(const Cgroup::spawn_arg& arg) {
+    // apply rlimit, note NPROC limit should be applied after setuid
+    FOR_EACH(p, arg.rlimits) {
+        int resource = p.first;
+        if (resource >= RLIMIT_NLIMITS) continue;
+
+        rlimit limit;
+        limit.rlim_cur = limit.rlim_max = p.second;
+
+        // wish to receive SIGXCPU or SIGXFSZ to know it is TLE or OLE.
+        // NOTE: if pid namespace is used (--isolate-process true), pid 1
+        // in the new pid ns is immune to signals (including SIGKILL) by
+        // default! This means that rlimit won't work for it. Therefore,
+        // a dummy init process is created if possible.
+        if (resource == RLIMIT_CPU || resource == RLIMIT_FSIZE) ++limit.rlim_max;
+
+        DEBUG_DO {
+            char limit_name[18];
+            switch (resource) {
+#define CONVERT_NAME(x) case x: strncpy(limit_name, # x, sizeof(limit_name)); break;
+                CONVERT_NAME(RLIMIT_CPU);
+                CONVERT_NAME(RLIMIT_FSIZE);
+                CONVERT_NAME(RLIMIT_DATA);
+                CONVERT_NAME(RLIMIT_STACK);
+                CONVERT_NAME(RLIMIT_CORE);
+                CONVERT_NAME(RLIMIT_RSS);
+                CONVERT_NAME(RLIMIT_NOFILE);
+                CONVERT_NAME(RLIMIT_AS);
+                CONVERT_NAME(RLIMIT_NPROC);
+                CONVERT_NAME(RLIMIT_MEMLOCK);
+                CONVERT_NAME(RLIMIT_LOCKS);
+                CONVERT_NAME(RLIMIT_SIGPENDING);
+                CONVERT_NAME(RLIMIT_MSGQUEUE);
+                CONVERT_NAME(RLIMIT_NICE);
+                CONVERT_NAME(RLIMIT_RTPRIO);
+                CONVERT_NAME(RLIMIT_RTTIME);
+#undef CONVERT_NAME
+                default:
+                    snprintf(limit_name, sizeof(limit_name), "0x%x", resource);
+            }
+            rlimit current;
+            getrlimit(resource, &current);
+            INFO("setrlimit %s, cur: %d => %d, max: %d => %d", limit_name,
+                 (int)current.rlim_cur, (int)limit.rlim_cur,
+                 (int)current.rlim_max, (int)limit.rlim_max);
+        }
+
+        if (setrlimit(resource, &limit)) {
+            WARNING("can not set rlimit %d", resource);
+        }
+    }
+}
+
+static void do_set_env(const Cgroup::spawn_arg& arg) {
+    // prepare env
+    if (arg.reset_env) {
+        INFO("reset ENV");
+        if (clearenv()) FATAL("can not clear env");
+    }
+
+    FOR_EACH(p, arg.env_list) {
+        const char * name = p.first.c_str();
+        const char * value = p.second.c_str();
+
+        if (setenv(name, value, 1)) FATAL("can not set env %s=%s", name, value);
+    }
+}
+
+static void do_seccomp(const Cgroup::spawn_arg& arg) {
+    // syscall whitelist
+    if (seccomp::supported() && arg.syscall_list.length() > 0) {
+        // apply seccomp, it will set PR_SET_NO_NEW_PRIVS
+        // libseccomp actually has an option to skip setting PR_SET_NO_NEW_PRIVS to 1
+        // however it makes seccomp_load error with EPERM because we just used setuid()
+        // and PR_SET_SECCOMP needs root if PR_SET_NO_NEW_PRIVS is unset.
+        INFO("applying syscall filters");
+        seccomp::Rules rules(arg.syscall_action, (uint64_t)(void*)arg.args /* special case for execve arg1 */);
+
+        if (rules.add_simple_filter(arg.syscall_list.c_str())) {
+            FATAL("failed to parse syscall filter string");
+            exit(-1);
+        }
+        if (rules.apply()) {
+            FATAL("failed to apply seccomp rules");
+            exit(-1);
+        }
+    }
+}
+
+static void do_set_new_privs(const Cgroup::spawn_arg& arg) {
+#ifndef PR_SET_NO_NEW_PRIVS
+# define PR_SET_NO_NEW_PRIVS 38
+#endif
+
+#ifndef PR_GET_NO_NEW_PRIVS
+# define PR_GET_NO_NEW_PRIVS 39
+#endif
+
+    if (arg.no_new_privs) {
+        int e = prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0);
+        if (e == -1) {
+            INFO("NO_NEW_PRIVS is not supported by kernel");
+        } else if (e == 0) {
+            INFO("prctl PR_SET_NO_NEW_PRIVS");
+            int e = prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+            if (e) {
+                FATAL("prctl PR_SET_NO_NEW_PRIVS");
+                exit(-1);
+            }
+        }
+    }
+}
+
+static void init_signal_handler(int signal) {
+    if (signal == SIGCHLD) {
+        int status;
+        while (waitpid(-1, &status, WNOHANG) > 0);
+    } else {
+        exit(1);
+    }
+}
+
+static int clone_init_fn(void *) {
+    // a dummy init process in new pid namespace
+    // intended to be killed via SIGKILL from root pid namespace
+    prctl(PR_SET_PDEATHSIG, SIGHUP);
+
+    {
+        struct sigaction action;
+        action.sa_handler = init_signal_handler;
+        sigemptyset(&action.sa_mask);
+        action.sa_flags = 0;
+        sigaction(SIGKILL, &action, NULL);
+        sigaction(SIGHUP, &action, NULL);
+        sigaction(SIGINT, &action, NULL);
+        sigaction(SIGTERM, &action, NULL);
+        sigaction(SIGABRT, &action, NULL);
+        sigaction(SIGQUIT, &action, NULL);
+        sigaction(SIGPIPE, &action, NULL);
+        sigaction(SIGALRM, &action, NULL);
+        sigaction(SIGCHLD, &action, NULL);
+    }
+
+    // close all fds
+    {
+        list<int> fds = get_fds();
+        INFO("init is running");
+        FOR_EACH(fd, fds) close(fd);
+    }
+
+    while (1) pause();
+    return 0;
+}
+
+static int clone_main_fn(void * clone_arg) {
+    // kill us if parent dies
+    prctl(PR_SET_PDEATHSIG, SIGKILL);
+
+    // this is executed in child process after clone
+    // fs and uid settings should be done here
+    Cgroup::spawn_arg& arg = *(Cgroup::spawn_arg*)clone_arg;
+
+#ifdef SYSCTL_PER_NS_WORKS
+    // NOTE: Do not uncomment this until sysctl per namespace works.
+    // current kernel use global variables for vm.oom_kill_allocating_task,
+    // etc.
+    do_set_sysctl();
+#endif
+    do_set_uts(arg);
+    do_set_netns(arg);
+    do_process_fds(arg);
+    do_privatize_filesystem(arg);
+    do_umount_outside_chroot(arg);
+    do_mount_proc(arg);
+    do_hide_sensitive(arg);
+    do_mount_bindfs(arg);
+    do_remounts(arg);
+    do_chroot(arg);
+    do_mount_tmpfs(arg);
+    do_remount_dev(arg);
+    do_chdir(arg);
+    do_commands(arg);
+    do_set_umask(arg);
+    do_set_uid_gid(arg);
+    do_apply_rlimits(arg);
+    do_set_env(arg);
+    do_renice(arg);
+    do_set_new_privs(arg);
+
+    // all prepared! blocking, wait for parent
+    INFO("waiting for parent");
+    char buf[4];
+    int ret = read(arg.sockets[0], buf, sizeof buf);
+    (void)ret;
+
+    // let parent know we got the message, parent then can close fd without SIGPIPE child
+    INFO("got from parent: '%3s'. notify parent", buf);
+    strncpy(buf, "PRE", sizeof buf);
+    ret = write(arg.sockets[0], buf, sizeof buf);
+    (void)ret;
+
+    // not closing sockets[0] here, it will closed on exec
+    // if exec fails, it will be closed upon process exit (aka. this function returns)
+    fd_set_cloexec(arg.sockets[0]);
+
+    // it's time for callback, write log first because fanotify may block us from
+    // doing that
+    int callback_ret = 0;
+    if (arg.callback_child) {
+        INFO("will run callback and execvp %s ...", arg.args[0]);
+        callback_ret = arg.callback_child((void *) &arg);
+    } else {
+        INFO("will execvp %s ...", arg.args[0]);
+    }
+
+    if (callback_ret == 0) {
+        // exec target. syscall filter must be done just before execve because we need other
+        // syscalls in above code.
+        do_seccomp(arg);
+        execvp(arg.args[0], arg.args);
+        // if exec fails, write reason down (child knows more details than parent)
+        ERROR("exec '%s' failed", arg.args[0]);
+    }
+
+    // exec or callback failed
+    // notify parent that exec failed
+    strncpy(buf, "ERR", sizeof buf);
+    ret = write(arg.sockets[0], buf, sizeof buf);
+    (void)ret;
+
+    // wait parent
+    ret = read(arg.sockets[0], buf, sizeof buf);
+    (void)ret;
+
+    return -1;
+} // clone_main_fn
+
+static int is_setns_pidns_supported() {
+    string pidns_path = string(fs::PROC_PATH) + "/self/ns/pid";
+    int fd = open(pidns_path.c_str(), O_RDONLY);
+    if (fd == -1) return 0;
+    close(fd);
+    return 1;
+}
+
+#ifndef NDEBUG
+static string clone_flags_to_str(int clone_flags) {
+    int v = clone_flags;
+    string s;
+#define TEST_FLAG(x) if ((v & x) != 0) { s += string(# x) + " | "; v ^= x; }
+    TEST_FLAG(CLONE_VM);
+    TEST_FLAG(CLONE_FS);
+    TEST_FLAG(CLONE_FILES);
+    TEST_FLAG(CLONE_SIGHAND);
+    TEST_FLAG(CLONE_PTRACE);
+    TEST_FLAG(CLONE_VFORK);
+    TEST_FLAG(CLONE_PARENT);
+    TEST_FLAG(CLONE_THREAD);
+    TEST_FLAG(CLONE_NEWNS);
+    TEST_FLAG(CLONE_SYSVSEM);
+    TEST_FLAG(CLONE_SETTLS);
+    TEST_FLAG(CLONE_PARENT_SETTID);
+    TEST_FLAG(CLONE_CHILD_CLEARTID);
+    TEST_FLAG(CLONE_DETACHED);
+    TEST_FLAG(CLONE_UNTRACED);
+    TEST_FLAG(CLONE_CHILD_SETTID);
+    TEST_FLAG(CLONE_NEWUTS);
+    TEST_FLAG(CLONE_NEWIPC);
+    TEST_FLAG(CLONE_NEWUSER);
+    TEST_FLAG(CLONE_NEWPID);
+    TEST_FLAG(CLONE_NEWNET);
+    TEST_FLAG(CLONE_IO);
+    TEST_FLAG(SIGCHLD);
+
+    TEST_FLAG(SIGINT);
+    TEST_FLAG(SIGQUIT);
+    TEST_FLAG(SIGILL);
+    TEST_FLAG(SIGTRAP);
+    TEST_FLAG(SIGABRT);
+    TEST_FLAG(SIGIOT);
+    TEST_FLAG(SIGBUS);
+    TEST_FLAG(SIGFPE);
+    TEST_FLAG(SIGKILL);
+    TEST_FLAG(SIGUSR1);
+    TEST_FLAG(SIGSEGV);
+    TEST_FLAG(SIGUSR2);
+    TEST_FLAG(SIGPIPE);
+    TEST_FLAG(SIGALRM);
+    TEST_FLAG(SIGTERM);
+    TEST_FLAG(SIGSTKFLT);
+    TEST_FLAG(SIGCLD);
+    TEST_FLAG(SIGCHLD);
+    TEST_FLAG(SIGCONT);
+    TEST_FLAG(SIGSTOP);
+    TEST_FLAG(SIGTSTP);
+    TEST_FLAG(SIGTTIN);
+    TEST_FLAG(SIGTTOU);
+    TEST_FLAG(SIGURG);
+    TEST_FLAG(SIGXCPU);
+    TEST_FLAG(SIGXFSZ);
+    TEST_FLAG(SIGVTALRM);
+    TEST_FLAG(SIGPROF);
+    TEST_FLAG(SIGWINCH);
+    TEST_FLAG(SIGPOLL);
+    TEST_FLAG(SIGIO);
+    TEST_FLAG(SIGPWR);
+    TEST_FLAG(SIGSYS);
+#ifdef SIGUNUSED
+    TEST_FLAG(SIGUNUSED);
+#endif
+#undef TEST_FLAG
+    if (v) {
+        s += strconv::from_long((long)v);
+    } else {
+        s = s.substr(0, s.length() - 3);
+    }
+    return s;
+}
+#endif
+
+pid_t Cgroup::spawn(spawn_arg& arg) {
+    // uid and gid should > 0
+    if (arg.uid <= 0 || arg.gid <= 0) {
+        WARNING("uid and gid can not <= 0. spawn rejected");
+        return -2;
+    }
+
+    // stack size for cloned processes
+    long stack_size = sysconf(_SC_PAGESIZE);
+    static const long MIN_STACK_SIZE = 8192;
+    if (stack_size < MIN_STACK_SIZE) stack_size = MIN_STACK_SIZE;
+
+    // We need root permissions and drop root later, no CLONE_NEWUSER here
+    // CLONE_NEWNS is required for private mounts
+    // CLONE_NEWUSER is not used because new uid 0 may be non-root
+    int clone_flags = CLONE_NEWNS | SIGCHLD | arg.clone_flags;
+
+    // older kernel (ex. Debian 7, 3.2.0) doesn't support setns(whatever, CLONE_PIDNS)
+    // just do not create init process in that case.
+    if (is_setns_pidns_supported() && (clone_flags & CLONE_NEWPID) == CLONE_NEWPID) {
+        // create a dummy init process in a new namespace
+        // CLONE_PTRACE: prevent the process being traced by another process
+        INFO("spawning dummy init process");
+        int init_clone_flags = CLONE_NEWPID;
+        init_pid_ = clone(clone_init_fn, (void*)((char*)alloca(stack_size) + stack_size), init_clone_flags, &arg);
+        if (init_pid_ < 0) {
+            ERROR("can not spawn init process");
+            return -3;
+        }
+
+        // switch to that pid namespace for our next clone
+        string pidns_path = string(fs::PROC_PATH) + "/" + strconv::from_ulong((unsigned long)init_pid_) + "/ns/pid";
+        INFO("set pid ns to %s", pidns_path.c_str());
+        int pidns_fd = open(pidns_path.c_str(), O_RDONLY);
+        if (pidns_fd < 0) {
+            ERROR("can not open pid namespace");
+            return -3;
+        }
+
+        // older glibc does not have setns
+        if (syscall(SYS_setns, pidns_fd, CLONE_NEWPID)) {
+            ERROR("can not set pid namespace");
+            return -3;
+        };
+        close(pidns_fd);
+
+        // remove CLONE_NEWPID flag because setns() will affect all new processes
+        clone_flags ^= CLONE_NEWPID;
+    } // spawn init process
+
+    DEBUG_DO {
+        INFO("clone flags = 0x%x = %s", (int)clone_flags, clone_flags_to_str(clone_flags).c_str());
+    }
+
+    // do sync use socket pair
+    if (socketpair(AF_LOCAL, SOCK_STREAM, 0, arg.sockets)) {
+        ERROR("socketpair failed");
+        return -1;
+    }
+
+    // sockets fds should expire when exec
+    fd_set_cloexec(arg.sockets[0]);
+    fd_set_cloexec(arg.sockets[1]);
+
+    pid_t child_pid;
+    child_pid = clone(clone_main_fn, (void*)((char*)alloca(stack_size) + stack_size), clone_flags, &arg);
+    char buf[4];
+    ssize_t ret;
+
+    if (child_pid < 0) {
+        FATAL("clone failed");
+        goto cleanup;
+    }
+
+    INFO("child pid = %lu", (unsigned long)child_pid);
+
+    // attach child to current cgroup. cpu and memory
+    // resource counter start to work from here
+    INFO("attach %lu", (unsigned long)child_pid);
+    attach(child_pid);
+
+    // child is blocking, waiting us before exec
+    // it's time to let the child go
+    strncpy(buf, "RUN", sizeof buf);
+    close(arg.sockets[0]);
+    ret = send(arg.sockets[1], buf, sizeof buf, MSG_NOSIGNAL);
+    if (ret < 0) {
+        WARNING("can not send let-go message to child");
+        goto cleanup;
+    }
+
+    // wait for child response
+    INFO("reading from child");
+
+    buf[0] = 0;
+    ret = read(arg.sockets[1], buf, sizeof buf);
+
+    INFO("from child, got '%3s'", buf);
+    if (buf[0] != 'P' || ret <= 0) {  // excepting "PRE"
+        // child has problem to start
+        child_pid = -3;
+        goto cleanup;
+    }
+
+    // child exec may fail, confirm
+    if (read(arg.sockets[1], buf, sizeof buf) > 0 && buf[0] == 'E') {  // "ERR"
+        INFO("seems child exec failed");
+        child_pid = -4;
+        goto cleanup;
+    }
+
+    // the child has exec successfully
+    // disable oom killer because it will make dmesg noisy.
+    // Note: a process can enter D (uninterruptable sleep) status
+    // when oom killer disabled, killing it requires re-enable oom killer
+    // or enlarge memory limit
+//    INFO("disabling oom killer");
+//    if (set(CG_MEMORY, "memory.oom_control", "1\n")) INFO("can not set memory.oom_control");
+
+    cleanup:
+    close(arg.sockets[1]);
+    return child_pid;
+}
+#endif

--- a/src/cgroup.h
+++ b/src/cgroup.h
@@ -31,402 +31,106 @@
 
 // Old system does not have RLIMIT_RTTIME, define it as invalid
 #ifndef RLIMIT_RTTIME
-# define RLIMIT_RTTIME RLIMIT_NLIMITS
+#define RLIMIT_RTTIME RLIMIT_NLIMITS
 #endif
 
 #if defined(CGROUP_VERSION) && CGROUP_VERSION == 2
-# define CGROUP_V2
+#define CGROUP_V2
 #else
-# define CGROUP_V1
+#define CGROUP_V1
 #endif
 
-#ifdef CGROUP_V1
 namespace lrun {
     class Cgroup;
-    typedef int cgroup_callback_func(void *);
 
-    class Cgroup {
-        public:
-
-            // Cgroup static methods
-
-            /**
-             * cgroup subsystem ids
-             */
-            enum subsys_id_t {
-                CG_CPUACCT = 0,
-                CG_MEMORY  = 1,
-                CG_DEVICES = 2,
-                CG_FREEZER = 3,
-            };
-
-            /**
-             * cgroup subsystem names
-             */
-            static const char subsys_names[4][8];
-            static const int SUBSYS_COUNT = sizeof(subsys_names) / sizeof(subsys_names[0]);
-
-            /**
-             * get cgroup subsystem id from name
-             * @param   name            cgroup subsystem name
-             * @return  >=0             cgroup subsystem id
-             *          -1              subsystem id not found
-             */
-            static int subsys_id_from_name(const char * const name);
-
-            /**
-             * get cgroup mounted path
-             * @param   create_on_need  mount cgroup if not mounted
-             * @return  cgroup mounted path (first one in mount table)
-             */
-            static std::string base_path(subsys_id_t subsys_id, bool create_on_need = true);
-
-
-            /**
-             * create a cgroup, use existing if possible
-             * @return  Cgroup object
-             */
-            static Cgroup create(const std::string& name);
-
-            /**
-             * @return  1           exist
-             *          0           not exist
-             */
-            static int exists(const std::string& name);
-
-            /**
-             * @param   subsys_id   cgroup subsystem id
-             * @param   name        group name
-             * @return  full path   "#{path_}/#{name}"
-             */
-            static std::string path_from_name(subsys_id_t subsys_id, const std::string& name);
-
-            /**
-             * @param   subsys_id   cgroup subsystem id
-             * @return  full path
-             */
-            std::string subsys_path(subsys_id_t subsys_id = CG_CPUACCT) const;
-
-            // Cgroup low level methods
-
-            /**
-             * kill all processes and destroy this cgroup
-             * @return 0            success
-             *         other        failed
-             */
-            int destroy();
-
-            /**
-             * set a cgroup property
-             * WARNING: property is not filtered, do not pass untrusted user-generated
-             * content here!
-             *
-             * @param   property    property
-             * @param   value       value
-             * @return  0           success
-             *         <0           failed
-             */
-            int set(subsys_id_t subsys_id, const std::string& property, const std::string& value);
-
-            /**
-             * get property
-             * @param   property    property
-             * @param   max_length  max length to read (not include '\0')
-             * @return  string      readed property, empty if fail
-             */
-            std::string get(subsys_id_t subsys_id, const std::string& property, size_t max_length = 255) const;
-
-            /**
-             * set a cgroup property to the same value as parent
-             * @param   property    property
-             * @return  0           success
-             *         <0           failed
-             */
-            int inherit(subsys_id_t subsys_id, const std::string& property);
-
-            /**
-             * attach a process
-             * @param   pid         process id to attach
-             * @return  0           success
-             *         <0           failed
-             */
-            int attach(pid_t pid);
-
-            /**
-             * check if Cgroup is invalid
-             * @return  true        valid
-             *          false       invalid
-             */
-            bool valid() const;
-
-
-            /**
-             * scan group processes and update output usage
-             */
-            void update_output_count();
-
-            /**
-             * return output usage
-             * @return  bytes      output usage
-             */
-            long long output_usage() const;
-
-            /**
-             * get pid list
-             * @return  pids       a list of pids in the cgroup
-             */
-            std::list<pid_t> get_pids();
-
-            // Cgroup high level methods
-
-            /**
-             * test if the cgroup has zero processes attached
-             * @return  1           yes, the cgroup has no processes attached
-             *          0           no, the cgroup has processes attached
-             */
-            int empty();
-
-            /**
-             * check if a process is in this cgroup
-             * @return  true        the process is in this cgroup
-             *          false       otherwise
-             */
-            bool has_pid(pid_t pid);
-
-            /**
-             * kill all tasks until no more tasks alive.
-             *
-             * @param   confirm     true: block until all tasks are confirmed gone
-             *                      false: just send kill, do not confirm
-             */
-            void killall(bool confirm = true);
-
-            /**
-             * use freezer cgroup subsystem to freeze processes
-             * if freeze is non-zero, the method will block until
-             * all processes are frozen.
-             * freezer may attempt increase memory limit and
-             * enable oom to get rid of D state processes.
-             *
-             * @param   freeze      false: unfreeze. true: freeze
-             * @param   timeout     how many iterations before giving up
-             * @return  0           success
-             *          otherwise   failed
-             */
-            int freeze(bool freeze = true, int timeout = 5);
-
-            /**
-             * get current memory usage
-             * @return  memory usage in bytes
-             */
-            long long memory_current() const;
-
-            /**
-             * get peak memory usage
-             * @return  memory usage in bytes
-             */
-            long long memory_peak() const;
-
-            /**
-             * get memory limit
-             * @return  memory limit in bytes
-             */
-            long long memory_limit() const;
-
-            /**
-             * test if the cgroup is under OOM
-             * @return  true   if under OOM
-             *          false  otherwise
-             */
-            bool is_under_oom() const;
-
-            /**
-             * get cpu usage
-             * @return  cpu usage in seconds
-             */
-            double cpu_usage() const;
-
-            /**
-             * set memory usage limit
-             * @param   bytes       limit, no limit if bytes <= 0
-             * @return >=0          success, real memory limit
-             *         <0           failed
-             */
-            long long set_memory_limit(long long bytes);
-
-            /**
-             * restart cpuacct and memory max_usage_in_bytes
-             * @return  0           success
-             *         <0           failed
-             */
-            int reset_usages();
-
-            /**
-             * restart cpuacct usage
-             * @return  0           success
-             *         <0           failed
-             */
-            int reset_cpu_usage();
-
-            /**
-             * limit devices to null, zero, full, random and urandom
-             *
-             * @return  0           success
-             *         <0           failed
-             */
-            int limit_devices();
-
-            /**
-             * structure used for forked child
-             */
-            struct spawn_arg {
-                int clone_flags;            // additional clone flags
-                char * const * args;        // exec args
-                int argc;                   // exec argc
-                uid_t uid;                  // uid (should not be 0)
-                gid_t gid;                  // gid (should not be 0)
-                mode_t umask;               // umask
-                int nice;                   // nice
-                bool no_new_privs;          // prctl PR_SET_NO_NEW_PRIVS
-                bool umount_outside;        // umount things outside chroot
-                int sockets[2];             // for sync between child and parent
-                std::string chroot_path;    // chroot path, empty if not need to chroot
-                std::string chdir_path;     // chdir path, empty if not need to chdir
-                std::string syscall_list;   // syscall whitelist or blacklist
-                int stdout_fd;              // redirect stdout to
-                int stderr_fd;              // redirect stderr to
-                int netns_fd;               // netns fd
-                struct {                    // set uts namespace strings
-                    std::string sysname;
-                    std::string nodename;
-                    std::string release;
-                    std::string version;
-                    std::string domainname;
-                } uts;
-                seccomp::action_t syscall_action;
-                                            // syscall default action
-                std::list<std::pair<std::string, long long> > tmpfs_list;
-                                            // [(dest, bytes)] mount tmpfs in child FS (after chroot)
-                std::list<std::pair<std::string, std::string> > bindfs_list;
-                std::set<std::string> bindfs_dest_set;
-                                            // [(dest, src)] mount bind in child FS (before chroot)
-                                            // bindfs_dests is for quickly lookup purpose
-                std::map<std::string, unsigned long> remount_list;
-                                            // [(dest, flags)] remount list (before chroot)
-                std::list<std::string> cmd_list;
-                                            // cp file list
-                std::set<int> keep_fds;     // Do not close these fd
-                std::map<int, rlim_t> rlimits;
-                                            // [resource, value] rlimit list
-                int reset_env;              // Do not inherit env
-                int remount_dev;            // Recreate a minimal dev
-                std::list<std::pair<std::string, std::string> > env_list;
-                                            // environment variables whitelist
-                cgroup_callback_func * callback_child;
-                                            // callback function, just *before* seccomp and execve.
-                                            // run in the context of child process
-            };
-
-            /**
-             * spawn child process and exec inside cgroup
-             * child process is in other namespace in FS, PID, UTS, IPC, NET
-             * child process is attached to cgroup just before exec
-             * @param   arg         swapn arg, @see struct spawn_arg
-             * @return  pid         child pid, negative if failed
-             */
-            pid_t spawn(spawn_arg& arg);
-
-        private:
-
-            Cgroup();
-
-            /**
-             * cgroup directory name
-             */
-            std::string name_;
-
-            /**
-             * count output bytes
-             */
-            std::map<unsigned long, unsigned long long> output_counter_;
-
-            /**
-             * cached init pid (only valid if pid namespace is enabled)
-             */
-            pid_t init_pid_;
-
-            /**
-             * cached paths
-             */
-            static std::string subsys_base_paths_[SUBSYS_COUNT];
-    };
-}
-#endif
-
-#ifdef CGROUP_V2
-namespace lrun {
-    class Cgroup;
     typedef int cgroup_callback_func(void *);
 
     class Cgroup {
     public:
-
         // Cgroup static methods
+#if defined(CGROUP_V1)
+        /**
+         * cgroup subsystem ids
+         */
+        enum subsys_id_t {
+            CG_CPUACCT = 0,
+            CG_MEMORY  = 1,
+            CG_DEVICES = 2,
+            CG_FREEZER = 3,
+        };
 
-//        /**
-//         * cgroup subsystem ids
-//         */
-//        enum subsys_id_t {
-//            CG_CGROUP = 0,
-//            CG_CPU  = 1,
-//            CG_MEMORY = 2,
-//            CG_DEVICE = 3,
-//        };
+        /**
+         * cgroup subsystem names
+         */
+        static const char subsys_names[4][8];
+        static const int SUBSYS_COUNT = sizeof(subsys_names) / sizeof(subsys_names[0]);
 
-//        /**
-//         * cgroup subsystem names
-//         */
-//        static const char subsys_names[4][8];
-//        static const int SUBSYS_COUNT = sizeof(subsys_names) / sizeof(subsys_names[0]);
-
-//        /**
-//         * get cgroup subsystem id from name
-//         * @param   name            cgroup subsystem name
-//         * @return  >=0             cgroup subsystem id
-//         *          -1              subsystem id not found
-//         */
-//        static int subsys_id_from_name(const char * const name);
+        /**
+         * get cgroup subsystem id from name
+         * @param   name            cgroup subsystem name
+         * @return  >=0             cgroup subsystem id
+         *          -1              subsystem id not found
+         */
+        static int subsys_id_from_name(const char * const name);
+#elif defined(CGROUP_V2)
+        /**
+         * only cgroup v1 have subsystems.
+         */
+#endif
 
         /**
          * get cgroup mounted path
          * @param   create_on_need  mount cgroup if not mounted
          * @return  cgroup mounted path (first one in mount table)
          */
+#if defined(CGROUP_V1)
+        static std::string base_path(subsys_id_t subsys_id, bool create_on_need = true);
+#elif defined(CGROUP_V2)
+
         static std::string base_path(bool create_on_need = true);
+
+#endif
 
 
         /**
          * create a cgroup, use existing if possible
          * @return  Cgroup object
          */
-        static Cgroup create(const std::string& name);
+        static Cgroup create(const std::string &name);
 
         /**
          * @return  1           exist
          *          0           not exist
          */
-        static int exists(const std::string& name);
+        static int exists(const std::string &name);
 
+#if defined(CGROUP_V1)
         /**
+         * @param   subsys_id   cgroup subsystem id
          * @param   name        group name
          * @return  full path   "#{path_}/#{name}"
          */
-        static std::string path_from_name(const std::string& name);
-
+        static std::string path_from_name(subsys_id_t subsys_id, const std::string& name);
+#elif defined(CGROUP_V2)
         /**
+        * @param   name        group name
+        * @return  full path   "#{path_}/#{name}"
+        */
+        static std::string path_from_name(const std::string &name);
+#endif
+
+#if defined(CGROUP_V1)
+        /**
+         * @param   subsys_id   cgroup subsystem id
          * @return  full path
          */
+        std::string subsys_path(subsys_id_t subsys_id = CG_CPUACCT) const;
+#elif defined(CGROUP_V2)
+        /**
+         * @return full path of group
+         */
         std::string group_path() const;
+#endif
 
         // Cgroup low level methods
 
@@ -447,7 +151,11 @@ namespace lrun {
          * @return  0           success
          *         <0           failed
          */
-        int set(const std::string& property, const std::string& value);
+#if defined(CGROUP_V1)
+        int set(subsys_id_t subsys_id, const std::string &property, const std::string &value);
+#elif defined(CGROUP_V2)
+        int set(const std::string &property, const std::string &value);
+#endif
 
         /**
          * get property
@@ -455,7 +163,11 @@ namespace lrun {
          * @param   max_length  max length to read (not include '\0')
          * @return  string      readed property, empty if fail
          */
-        std::string get(const std::string& property, size_t max_length = 255) const;
+#if defined(CGROUP_V1)
+        std::string get(subsys_id_t subsys_id, const std::string &property, size_t max_length = 255) const;
+#elif defined(CGROUP_V2)
+        std::string get(const std::string &property, size_t max_length = 255) const;
+#endif
 
         /**
          * set a cgroup property to the same value as parent
@@ -463,7 +175,11 @@ namespace lrun {
          * @return  0           success
          *         <0           failed
          */
-        int inherit(const std::string& property);
+#if defined(CGROUP_V1)
+        int inherit(subsys_id_t subsys_id, const std::string &property);
+#elif defined(CGROUP_V2)
+        int inherit(const std::string &property);
+#endif
 
         /**
          * attach a process
@@ -602,7 +318,7 @@ namespace lrun {
          */
         struct spawn_arg {
             int clone_flags;            // additional clone flags
-            char * const * args;        // exec args
+            char *const *args;        // exec args
             int argc;                   // exec argc
             uid_t uid;                  // uid (should not be 0)
             gid_t gid;                  // gid (should not be 0)
@@ -643,7 +359,7 @@ namespace lrun {
             int remount_dev;            // Recreate a minimal dev
             std::list<std::pair<std::string, std::string> > env_list;
             // environment variables whitelist
-            cgroup_callback_func * callback_child;
+            cgroup_callback_func *callback_child;
             // callback function, just *before* seccomp and execve.
             // run in the context of child process
         };
@@ -655,7 +371,7 @@ namespace lrun {
          * @param   arg         swapn arg, @see struct spawn_arg
          * @return  pid         child pid, negative if failed
          */
-        pid_t spawn(spawn_arg& arg);
+        pid_t spawn(spawn_arg &arg);
 
     private:
 
@@ -676,10 +392,15 @@ namespace lrun {
          */
         pid_t init_pid_;
 
-//        /**
-//         * cached paths
-//         */
-//        static std::string subsys_base_paths_[SUBSYS_COUNT];
+#if defined(CGROUP_V1)
+        /**
+         * cached paths
+         */
+        static std::string subsys_base_paths_[SUBSYS_COUNT];
+#elif defined(CGROUP_V2)
+        /**
+         * only cgroup v1 have subsystems.
+         */
+#endif
     };
 }
-#endif

--- a/src/config.cc
+++ b/src/config.cc
@@ -217,6 +217,7 @@ void MainConfig::check() {
                     "Non-root users cannot use `--cgroup-option`");
         }
 
+#ifdef CGROUP_V1
         FOR_EACH(p, this->cgroup_options) {
             const string& key = p.first.second;
             if (key.find("..") != string::npos || key.find("/") != string::npos) {
@@ -224,6 +225,16 @@ void MainConfig::check() {
                         "Invalid cgroup option key: `" + key + "`");
             }
         }
+#endif
+#ifdef CGROUP_V2
+        FOR_EACH(p, this->cgroup_options) {
+            const string& key = p.first;
+            if (key.find("..") != string::npos || key.find("/") != string::npos) {
+                error_messages.push_back(
+                        "Invalid cgroup option key: `" + key + "`");
+            }
+        }
+#endif
     }
 
     if (this->arg.syscall_list.empty() && this->arg.syscall_action == seccomp::action_t::DEFAULT_EPERM) {

--- a/src/config.h
+++ b/src/config.h
@@ -46,8 +46,12 @@ namespace lrun {
         Cgroup* active_cgroup;
 
         std::vector<gid_t> groups;
+#ifdef CGROUP_V1
         std::map<std::pair<Cgroup::subsys_id_t, std::string>, std::string> cgroup_options;
-
+#endif
+#ifdef CGROUP_V2
+        std::map<std::string, std::string> cgroup_options;
+#endif
         MainConfig();
 
         // check config permissions. print errors and exit

--- a/src/options/fopen_filter.cc
+++ b/src/options/fopen_filter.cc
@@ -31,6 +31,7 @@
 #include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <thread>
 #include "options.h"
 #include "../utils/ensure.h"
 #include "../utils/fs.h"
@@ -232,7 +233,6 @@ static inline int do_mark_paths() {
     for (size_t i = 0; i < conditions.size(); ++i) {
         int mark_flag = conditions[i]->get_mark_flags();
         std::string path = conditions[i]->get_mark_path();
-
         if (!path.empty()) {
             int ret = tracer->mark(path.c_str(), mark_flag | FAN_MARK_ADD, FAN_OPEN_PERM);
             if (ret != 0) {

--- a/src/options/parse.cc
+++ b/src/options/parse.cc
@@ -21,6 +21,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <string>
+#include <thread>
 #include "../utils/strconv.h"
 #include "../utils/fs.h"
 #include "options.h"
@@ -241,6 +242,7 @@ void lrun::options::parse(int argc, char * argv[], lrun::MainConfig& config) {
             long long bytes = strconv::to_bytes(NEXT_STRING_ARG);
             config.arg.tmpfs_list.push_back(make_pair(path, bytes));
         } else if (option == "cgroup-option") {
+#ifdef CGROUP_V1
             REQUIRE_NARGV(3);
             string subsys_name = NEXT_STRING_ARG;
             string key = NEXT_STRING_ARG;
@@ -258,6 +260,18 @@ void lrun::options::parse(int argc, char * argv[], lrun::MainConfig& config) {
                         "subsystem '%s' not found",
                         key.c_str(), value.c_str(), subsys_name.c_str());
             }
+#endif
+#ifdef CGROUP_V2
+            REQUIRE_NARGV(2);
+            string key = NEXT_STRING_ARG;
+            string value = NEXT_STRING_ARG;
+            if (key.find("..") != string::npos || key.find('/') != string::npos) {
+                WARNING("unsafe cgroup option '%s' = '%s' ignored",
+                        key.c_str(), value.c_str());
+            } else {
+                config.cgroup_options[key] = value;
+            }
+#endif
         } else if (option == "env") {
             REQUIRE_NARGV(2);
             string key = NEXT_STRING_ARG;

--- a/src/utils/fs.cc
+++ b/src/utils/fs.cc
@@ -45,6 +45,7 @@ const char * const fs::PROC_PATH = "/proc";
 const char * const fs::MOUNTS_PATH = "/proc/mounts";
 const char * const fs::NETNS_PATH = "/var/run/netns";
 const char * const fs::TYPE_CGROUP = "cgroup";
+const char * const fs::TYPE_CGROUP2 = "cgroup2";
 const char * const fs::TYPE_TMPFS  = "tmpfs";
 
 string fs::join(const string& dirname, const string& basename) {

--- a/src/utils/fs.h
+++ b/src/utils/fs.h
@@ -79,6 +79,11 @@ namespace fs {
     extern const char * const TYPE_CGROUP;
 
     /**
+     * Cgroup v2 filesystem type name: "cgroup2"
+     */
+    extern const char * const TYPE_CGROUP2;
+
+    /**
      * tmpfs type name: "tmpfs"
      */
     extern const char * const TYPE_TMPFS;

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN sed -i 's/archive.ubuntu.com/mirrors.ustc.edu.cn/g' /etc/apt/sources.list && \
+    sed -i 's/security.ubuntu.com/mirrors.ustc.edu.cn/g' /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y build-essential libseccomp2 libseccomp-dev rake pkg-config git
+
+RUN groupadd -r -g 593 lrun && \
+    useradd --uid 1000 --gid lrun --shell /bin/bash -m judger

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(PROJECT test)
+
+project(${PROJECT} VERSION 0.1 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(fs_unit_test
+        test.h
+        test.cc
+        ../src/utils/fs.h
+        ../src/utils/fs.cc
+        fs_unit_test.cc)
+add_test(NAME fs_unit_test COMMAND fs_unit_test)
+
+add_executable(cgroup_unit_test
+        test.h
+        test.cc
+        ../src/cgroup.h
+        ../src/cgroup.cc
+        ../src/utils/strconv.h
+        ../src/utils/strconv.cc
+        ../src/utils/fs.h
+        ../src/utils/fs.cc
+        ../src/utils/now.h
+        ../src/utils/now.cc
+        ../src/utils/log.h
+        ../src/utils/log.cc
+        ../src/seccomp.h
+        ../src/seccomp.cc
+        cgroup_unit_test.cc)
+add_test(NAME cgroup_unit_test COMMAND cgroup_unit_test)
+
+if($ENV{NOSECCOMP})
+    add_definitions(-DLIBSECCOMP_VERSION_MAJOR=0)
+else()
+    execute_process(COMMAND pkg-config --modversion libseccomp OUTPUT_VARIABLE LIBSECCOMP_VERSION)
+    if(${LIBSECCOMP_VERSION} MATCHES "2.*")
+        target_compile_definitions(cgroup_unit_test PUBLIC -DLIBSECCOMP_VERSION_MAJOR=2)
+        find_package(PkgConfig)
+        pkg_search_module(SECCOMP REQUIRED libseccomp)
+        target_include_directories(cgroup_unit_test BEFORE PRIVATE ${SECCOMP_INCLUDE_DIRS})
+        target_link_libraries(cgroup_unit_test PUBLIC ${SECCOMP_LIBRARIES})
+    endif()
+endif()
+
+execute_process(COMMAND bash -c "mount -l | grep \"/sys/fs/cgroup type cgroup2\"" RESULT_VARIABLE CGROUP_CHECK)
+if(${CGROUP_CHECK} EQUAL "0")
+    message("Detected cgroup v2, setting CGROUP_VERSION=2")
+    target_compile_definitions(cgroup_unit_test PUBLIC -DCGROUP_VERSION=2)
+else()
+    message("No cgroup v2, setting CGROUP_VERSION=1")
+    target_compile_definitions(cgroup_unit_test PUBLIC -DCGROUP_VERSION=1)
+endif()
+add_custom_command(TARGET cgroup_unit_test POST_BUILD COMMAND sudo install -D -m4550 -oroot -glrun ${CMAKE_CURRENT_BINARY_DIR}/cgroup_unit_test ${CMAKE_BINARY_DIR}/cgroup_unit_test)
+
+add_executable(strconv_unit_test
+        test.h
+        test.cc
+        ../src/utils/strconv.h
+        ../src/utils/strconv.cc
+        strconv_unit_test.cc)
+add_test(NAME strconv_unit_test COMMAND strconv_unit_test)
+
+add_executable(integration_test
+        test.h
+        test.cc
+        integration_test.cc)
+add_test(NAME integration_test COMMAND integration_test)
+add_custom_command(TARGET integration_test POST_BUILD COMMAND sudo install -D -m4550 -oroot -glrun ${CMAKE_CURRENT_BINARY_DIR}/integration_test ${CMAKE_BINARY_DIR}/integration_test)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,5 @@
 BINARIES=fs_unit_test cgroup_unit_test strconv_unit_test integration_test
-CXXFLAGS=-I../src -g -std=c++0x -Wall
+CXXFLAGS=-I../src -g -std=c++0x -Wall -DCGROUP_VERSION=2
 LD_SECCOMP_FLAGS=`pkg-config --libs --silence-errors libseccomp`
 LD=g++
 

--- a/test/cgroup_unit_test.cc
+++ b/test/cgroup_unit_test.cc
@@ -20,13 +20,17 @@
 // THE SOFTWARE.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "cgroup.h"
+#include "../src/cgroup.h"
 #include "test.h"
 
 using namespace lrun;
 
 TESTCASE(get_path) {
+#if defined(CGROUP_V1)
     CHECK(!Cgroup::base_path(Cgroup::CG_CPUACCT, true).empty());
+#elif defined(CGROUP_V2)
+    CHECK(!Cgroup::base_path(true).empty());
+#endif
 }
 
 TESTCASE(create_and_destroy) {
@@ -39,8 +43,13 @@ TESTCASE(create_and_destroy) {
 TESTCASE(set_properties) {
     Cgroup cg = Cgroup::create("testsetprop");
     // FIXME assume no swap here
+#if defined(CGROUP_V1)
     CHECK(cg.set(Cgroup::CG_MEMORY, "memory.limit_in_bytes", "1048576") == 0);
     CHECK(cg.get(Cgroup::CG_MEMORY, "memory.limit_in_bytes") == "1048576\n");
+#elif defined(CGROUP_V2)
+    CHECK(cg.set("memory.max", "1048576") == 0);
+    CHECK(cg.get("memory.max") == "1048576\n");
+#endif
     CHECK(cg.reset_usages() == 0);
     CHECK(cg.destroy() == 0);
 }

--- a/test/fs_unit_test.cc
+++ b/test/fs_unit_test.cc
@@ -86,7 +86,7 @@ TESTCASE(is_accessible) {
     CHECK(fs::is_accessible(TMP "/_a1", R_OK, TMP));
     CHECK(!fs::is_accessible(TMP "/_an", R_OK, TMP));
     CHECK(fs::is_accessible("/dev/null", W_OK));
-    CHECK(fs::is_accessible("/bin/bash", R_OK));
+    CHECK(fs::is_accessible("/usr/bin/env", R_OK));
     CHECK(!fs::is_accessible("/proc/self/io", W_OK));
     CHECK(!fs::is_accessible("/proc/self/io", X_OK));
     CHECK(fs::is_accessible(TMP, X_OK));
@@ -216,7 +216,7 @@ TESTCASE(mount_tmpfs) {
         // write test
         CHECK(system("echo hello > " TMP "/_mt/ee") == 0);
         // size limit test
-        CHECK(system("cat /bin/bash >> " TMP "/_mt/ee 2>/dev/null") != 0);
+        CHECK(system("cat /usr/bin/env >> " TMP "/_mt/ee 2>/dev/null") != 0);
         system("umount " TMP "/_mt");
         // file should disapper after umount
         CHECK(system("test -e " TMP "/_mt/ee") != 0);
@@ -246,6 +246,6 @@ TESTCASE(is_dir) {
     CHECK(fs::is_dir("/"));
     CHECK(!fs::is_dir("/proc1/self"));
     CHECK(!fs::is_dir(""));
-    CHECK(!fs::is_dir("/bin/bash"));
+    CHECK(!fs::is_dir("/usr/bin/env"));
     CHECK(!fs::is_dir("/bin/ping"));
 }

--- a/test/integration_test.cc
+++ b/test/integration_test.cc
@@ -118,8 +118,9 @@ TESTCASE(signal) {
         // this one may fail if pid namespace is not fully supported
         // and --isolate-process is true.
         // do not report a bug if you are using linux < 3.8
-        test_c_code("main(){kill(getpid(), 33);}",
-                    "TERMSIG  33",
+        // 33 code is not supported by later gcc, it will become `unknown signal 33`, so use valid signal here.
+        test_c_code("main(){kill(getpid(), 31);}",
+                    "TERMSIG  31",
                     c.flag);
     }
 }
@@ -162,7 +163,7 @@ TESTCASE(syscall_filter) {
 
     // test execve special case handling
     test_cmd("true", "EXITCODE 0", "--syscalls '!execve'");
-    test_cmd("true", "EXITCODE 0", "--syscalls 'access,arch_prctl,brk,close,exit_group,fstat,mmap,mprotect,munmap,open,openat,read,exit'");
+    test_cmd("true", "EXITCODE 0", "--syscalls 'access,arch_prctl,brk,close,exit_group,mmap,mprotect,munmap,newfstatat,open,openat,pread64,read,exit'");
     test_cmd("true", "EXITCODE 0", "--syscalls '!execve:a'");
     test_cmd("true", "EXITCODE 0", "--syscalls '!open:a'");
     test_cmd("env true", "EXITCODE 1" /* 126 */, "--syscalls '!execve'");

--- a/test/strconv_unit_test.cc
+++ b/test/strconv_unit_test.cc
@@ -21,7 +21,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "test.h"
-#include "utils/strconv.h"
+#include "../src/utils/strconv.h"
 
 using namespace strconv;
 


### PR DESCRIPTION
#### fix pintia/issues#

- [ ] break change (should be carefully deployed)

#### Proposed Changes

- add support for cgroups v2
- ~~cgroups 的文档里，旧的文档没有写 memory.peak，但新的里有 memory.peak，lrun 依赖这个特性，所以可以再等等。我运行的5.15.53 的内核里还没有，所以不能正常获取到内存使用量。~~ 5.19+支持了
- device controller 需要重新实现，要用 bpf，相关内容写在了 issue 里，难度不小
- 还需要修测试